### PR TITLE
SP-151 Crash in catapult on HashLockTransaction

### DIFF
--- a/extensions/harvesting/src/BlockStateHashCalculator.h
+++ b/extensions/harvesting/src/BlockStateHashCalculator.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "catapult/types.h"
+#include "catapult/model/Elements.h"
 
 namespace catapult {
 	namespace cache { class CatapultCache; }
@@ -32,10 +33,10 @@ namespace catapult {
 
 namespace catapult { namespace harvesting {
 
-	/// Calculates the state hash after executing \a block given \a cache for the network configured with \a config
+	/// Calculates the state hash after executing \a blockElements given \a cache for the network configured with \a config
 	/// and \a pluginManager.
 	std::pair<Hash256, bool> CalculateBlockStateHash(
-			const model::Block& block,
+			const model::BlockElement& blockElements,
 			const cache::CatapultCache& cache,
 			const model::BlockChainConfiguration& config,
 			const plugins::PluginManager& pluginManager);

--- a/extensions/harvesting/src/Harvester.cpp
+++ b/extensions/harvesting/src/Harvester.cpp
@@ -28,6 +28,18 @@
 namespace catapult { namespace harvesting {
 
 	namespace {
+
+		model::BlockElement ToBlockElement(const model::Block& block, const std::vector<const model::TransactionInfo*>& transactionInfos) {
+			model::BlockElement blockElement(block);
+
+			for (const auto& transactionInfo : transactionInfos) {
+				blockElement.Transactions.push_back(model::TransactionElement(*transactionInfo->pEntity));
+				blockElement.Transactions.back().EntityHash = transactionInfo->EntityHash;
+			}
+
+			return blockElement;
+		}
+
 		struct NextBlockContext {
 		public:
 			explicit NextBlockContext(const model::BlockElement& parentBlockElement, Timestamp nextTimestamp)
@@ -113,7 +125,7 @@ namespace catapult { namespace harvesting {
 
 		auto transactionsInfo = m_suppliers.SupplyTransactions(m_config.MaxTransactionsPerBlock);
 		auto pBlock = CreateUnsignedBlock(context, m_config.Network.Identifier, *pHarvesterKeyPair, transactionsInfo);
-		auto stateHashResult = m_suppliers.CalculateStateHash(*pBlock);
+		auto stateHashResult = m_suppliers.CalculateStateHash(ToBlockElement(*pBlock, transactionsInfo.Infos));
 		if (!stateHashResult.second)
 			return nullptr;
 

--- a/extensions/harvesting/src/Harvester.h
+++ b/extensions/harvesting/src/Harvester.h
@@ -34,7 +34,7 @@ namespace catapult { namespace harvesting {
 		/// Suppliers used to customize block generation.
 		struct Suppliers {
 			/// Calculates a state hash for a block.
-			std::function<std::pair<Hash256, bool> (const model::Block&)> CalculateStateHash;
+			std::function<std::pair<Hash256, bool> (const model::BlockElement&)> CalculateStateHash;
 
 			/// Supplies transaction infos for a block.
 			TransactionsInfoSupplier SupplyTransactions;

--- a/extensions/harvesting/src/HarvestingService.cpp
+++ b/extensions/harvesting/src/HarvestingService.cpp
@@ -76,8 +76,8 @@ namespace catapult { namespace harvesting {
 			const auto& blockChainConfig = state.config().BlockChain;
 
 			Harvester::Suppliers harvesterSuppliers{
-				[&cache, &blockChainConfig, &pluginManager = state.pluginManager()](const auto& block) {
-					return CalculateBlockStateHash(block, cache, blockChainConfig, pluginManager);
+				[&cache, &blockChainConfig, &pluginManager = state.pluginManager()](const auto& blockElements) {
+					return CalculateBlockStateHash(blockElements, cache, blockChainConfig, pluginManager);
 				},
 				CreateTransactionsInfoSupplier(state.utCache())
 			};

--- a/extensions/harvesting/src/TransactionsInfo.cpp
+++ b/extensions/harvesting/src/TransactionsInfo.cpp
@@ -26,18 +26,17 @@ namespace catapult { namespace harvesting {
 	TransactionsInfoSupplier CreateTransactionsInfoSupplier(const cache::MemoryUtCache& utCache) {
 		return [&utCache](auto count) {
 			TransactionsInfo info;
-			std::vector<const model::TransactionInfo*> transactionInfos;
 
 			auto view = utCache.view();
 			if (0 != count) {
-				view.forEach([count, &info, &transactionInfos](const auto& transactionInfo) {
+				view.forEach([count, &info](const auto& transactionInfo) {
+					info.Infos.push_back(&transactionInfo);
 					info.Transactions.push_back(transactionInfo.pEntity);
-					transactionInfos.push_back(&transactionInfo);
 					return info.Transactions.size() != count;
 				});
 			}
 
-			CalculateBlockTransactionsHash(transactionInfos, info.TransactionsHash);
+			CalculateBlockTransactionsHash(info.Infos, info.TransactionsHash);
 			return info;
 		};
 	}

--- a/extensions/harvesting/src/TransactionsInfo.h
+++ b/extensions/harvesting/src/TransactionsInfo.h
@@ -29,6 +29,7 @@ namespace catapult { namespace harvesting {
 	struct TransactionsInfo {
 		/// Transactions.
 		model::Transactions Transactions;
+		std::vector<const model::TransactionInfo*> Infos;
 
 		/// Aggregate transactions hash.
 		Hash256 TransactionsHash;

--- a/extensions/harvesting/tests/BlockStateHashCalculatorTests.cpp
+++ b/extensions/harvesting/tests/BlockStateHashCalculatorTests.cpp
@@ -50,6 +50,7 @@ namespace catapult { namespace harvesting {
 		void RunTest(bool enableVerifiableState, Height blockHeight, uint32_t numTransactions, TAssertHashes assertHashes) {
 			// Arrange:
 			auto pBlock = test::GenerateBlockWithTransactions(numTransactions, blockHeight, Timestamp());
+			auto blockElement = test::BlockToBlockElement(*pBlock);
 			ZeroTransactionFees(*pBlock);
 
 			test::TempDirectoryGuard dbDirGuard("testdb");
@@ -72,7 +73,7 @@ namespace catapult { namespace harvesting {
 			auto preCacheStateHash = cache.createView().calculateStateHash().StateHash;
 
 			// Act:
-			auto blockStateHashResult = CalculateBlockStateHash(*pBlock, cache, config, *pPluginManager);
+			auto blockStateHashResult = CalculateBlockStateHash(blockElement, cache, config, *pPluginManager);
 			auto postCacheStateHash = cache.createView().calculateStateHash().StateHash;
 
 			// Assert: cache state hash should not change
@@ -145,8 +146,8 @@ namespace catapult { namespace harvesting {
 			pPluginManager->addTransactionSupport(mocks::CreateMockTransactionPlugin());
 
 			// Act:
-			auto blockStateHashResult1 = CalculateBlockStateHash(block1, cache, config, *pPluginManager);
-			auto blockStateHashResult2 = CalculateBlockStateHash(block2, cache, config, *pPluginManager);
+			auto blockStateHashResult1 = CalculateBlockStateHash(test::BlockToBlockElement(block1), cache, config, *pPluginManager);
+			auto blockStateHashResult2 = CalculateBlockStateHash(test::BlockToBlockElement(block2), cache, config, *pPluginManager);
 
 			// Assert:
 			EXPECT_TRUE(blockStateHashResult1.second);
@@ -203,10 +204,11 @@ namespace catapult { namespace harvesting {
 			});
 
 			auto pBlock = test::GenerateBlockWithTransactionsAtHeight(numTransactions, Height(2));
+			auto blockElement = test::BlockToBlockElement(*pBlock);
 			ZeroTransactionFees(*pBlock);
 
 			// Act: calculate state hash
-			CalculateBlockStateHash(*pBlock, cache, config, *pPluginManager);
+			CalculateBlockStateHash(blockElement, cache, config, *pPluginManager);
 
 			// Assert: all transaction hashes are unique
 			EXPECT_EQ(numTransactions, capturedHashes.size());

--- a/extensions/harvesting/tests/HarvesterTests.cpp
+++ b/extensions/harvesting/tests/HarvesterTests.cpp
@@ -463,10 +463,10 @@ namespace catapult { namespace harvesting {
 		auto stateHash = test::GenerateRandomData<Hash256_Size>();
 		std::vector<Hash256> capturedPreviousBlockHashes;
 		Harvester::Suppliers harvesterSuppliers{
-			[&stateHash, &capturedPreviousBlockHashes](const auto& block) {
+			[&stateHash, &capturedPreviousBlockHashes](const auto& blockElement) {
 				// - use previous block hash as a proxy for a block
-				capturedPreviousBlockHashes.push_back(block.PreviousBlockHash);
-				stateHash[3] = block.PreviousBlockHash[0];
+				capturedPreviousBlockHashes.push_back(blockElement.Block.PreviousBlockHash);
+				stateHash[3] = blockElement.Block.PreviousBlockHash[0];
 				return std::make_pair(stateHash, true);
 			},
 			[](auto) { return TransactionsInfo(); }


### PR DESCRIPTION
The fix for the bug with crash during harvesting of hash lock transaction.

After Bison update at the end of harvesting we started calculate a block stateHash. For that we create a delta cache and execute blockElement, where the BlockElement has a faked hashes of transactions.

Part of code with it:

// just need to extract transactions in order to execute them
// since there is no validation, hashes only need to be unique (to avoid redundant hash cache insert) but don't need to be correct
model::BlockElement ExplodeToBlockElement(const model::Block& block) {
	model::BlockElement blockElement(block);

	auto counter = 0u;
	for (const auto& transaction : block.Transactions()) {
		blockElement.Transactions.push_back(model::TransactionElement(transaction));

		auto& entityHash = blockElement.Transactions.back().EntityHash;
		reinterpret_cast<uint32_t&>(*entityHash.data()) = ++counter;
	}

	return blockElement;
}

During execution of blockElement we will trigger CompletedAggregateObserver, which try to find a hash of transaction in the cache. But the hash is not valid and it causes an error.

Now we set a valid hashes instead of faked to blockElement, when we want to calculate a block stateHash