### PR TITLE
PC-68 Not valid notifications during rollback

### DIFF
--- a/plugins/txes/accountlink/src/model/AccountLinkNotifications.h
+++ b/plugins/txes/accountlink/src/model/AccountLinkNotifications.h
@@ -41,7 +41,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a remote account link.
-	struct RemoteAccountLinkNotification : public Notification {
+	struct RemoteAccountLinkNotification : public CloneableNotification<RemoteAccountLinkNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = AccountLink_Remote_Notification;
@@ -49,7 +49,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a mainAccountKey, \a remoteAccountKey and \a linkAction.
 		RemoteAccountLinkNotification(const Key& mainAccountKey, const Key& remoteAccountKey, AccountLinkAction linkAction)
-				: Notification(Notification_Type, sizeof(RemoteAccountLinkNotification))
+				: CloneableNotification(Notification_Type, sizeof(RemoteAccountLinkNotification))
 				, MainAccountKey(mainAccountKey)
 				, RemoteAccountKey(remoteAccountKey)
 				, LinkAction(linkAction)
@@ -67,7 +67,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a new remote account.
-	struct NewRemoteAccountNotification : public Notification {
+	struct NewRemoteAccountNotification : public CloneableNotification<NewRemoteAccountNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = AccountLink_New_Remote_Account_Notification;
@@ -75,7 +75,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a remoteAccountKey.
 		explicit NewRemoteAccountNotification(const Key& remoteAccountKey)
-				: Notification(Notification_Type, sizeof(NewRemoteAccountNotification))
+				: CloneableNotification(Notification_Type, sizeof(NewRemoteAccountNotification))
 				, RemoteAccountKey(remoteAccountKey)
 		{}
 

--- a/plugins/txes/aggregate/src/model/AggregateNotifications.h
+++ b/plugins/txes/aggregate/src/model/AggregateNotifications.h
@@ -42,11 +42,13 @@ namespace catapult { namespace model {
 
 	/// A basic aggregate notification.
 	template<typename TDerivedNotification>
-	struct BasicAggregateNotification : public Notification {
+	struct BasicAggregateNotification : public CloneableNotification<BasicAggregateNotification<TDerivedNotification>, Notification> {
 	public:
 		/// Creates a notification around \a signer, \a cosignaturesCount and \a pCosignatures.
 		explicit BasicAggregateNotification(const Key& signer, size_t cosignaturesCount, const Cosignature* pCosignatures)
-				: Notification(TDerivedNotification::Notification_Type, sizeof(TDerivedNotification))
+				: CloneableNotification<BasicAggregateNotification<TDerivedNotification>, Notification>(
+						TDerivedNotification::Notification_Type,
+						sizeof(TDerivedNotification))
 				, Signer(signer)
 				, CosignaturesCount(cosignaturesCount)
 				, CosignaturesPtr(pCosignatures)
@@ -64,7 +66,8 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of an embedded aggregate transaction with cosignatures.
-	struct AggregateEmbeddedTransactionNotification : public BasicAggregateNotification<AggregateEmbeddedTransactionNotification> {
+	struct AggregateEmbeddedTransactionNotification : public CloneableNotification<AggregateEmbeddedTransactionNotification,
+			BasicAggregateNotification<AggregateEmbeddedTransactionNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Aggregate_EmbeddedTransaction_Notification;
@@ -76,7 +79,7 @@ namespace catapult { namespace model {
 				const EmbeddedTransaction& transaction,
 				size_t cosignaturesCount,
 				const Cosignature* pCosignatures)
-				: BasicAggregateNotification<AggregateEmbeddedTransactionNotification>(signer, cosignaturesCount, pCosignatures)
+				: CloneableNotification(signer, cosignaturesCount, pCosignatures)
 				, Transaction(transaction)
 		{}
 
@@ -87,7 +90,8 @@ namespace catapult { namespace model {
 
 	/// Notification of an aggregate transaction with transactions and cosignatures.
 	/// \note TransactionsPtr and CosignaturesPtr are provided instead of minimally required keys in order to support undoing.
-	struct AggregateCosignaturesNotification : public BasicAggregateNotification<AggregateCosignaturesNotification> {
+	struct AggregateCosignaturesNotification : public CloneableNotification<AggregateCosignaturesNotification,
+			BasicAggregateNotification<AggregateCosignaturesNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Aggregate_Cosignatures_Notification;
@@ -100,7 +104,7 @@ namespace catapult { namespace model {
 				const EmbeddedTransaction* pTransactions,
 				size_t cosignaturesCount,
 				const Cosignature* pCosignatures)
-				: BasicAggregateNotification<AggregateCosignaturesNotification>(signer, cosignaturesCount, pCosignatures)
+				: CloneableNotification(signer, cosignaturesCount, pCosignatures)
 				, TransactionsCount(transactionsCount)
 				, TransactionsPtr(pTransactions)
 		{}

--- a/plugins/txes/contract/src/model/ContractNotifications.h
+++ b/plugins/txes/contract/src/model/ContractNotifications.h
@@ -32,7 +32,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a reputation update.
-	struct ReputationUpdateNotification : public Notification {
+	struct ReputationUpdateNotification : public CloneableNotification<ReputationUpdateNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Reputation_Update_Notification;
@@ -41,13 +41,13 @@ namespace catapult { namespace model {
 		/// Creates a notification around \a signer, \a modificationCount and \a pModifications.
 		explicit ReputationUpdateNotification(
 			const std::vector<CosignatoryModification>& modifications)
-			: Notification(Notification_Type, sizeof(ReputationUpdateNotification))
+			: CloneableNotification(Notification_Type, sizeof(ReputationUpdateNotification))
 			, Modifications(modifications)
 		{}
 
 	public:
 		/// Const pointer to the first modification.
-		const std::vector<CosignatoryModification>& Modifications;
+		std::vector<CosignatoryModification> Modifications;
 	};
 
 	// endregion
@@ -60,7 +60,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a contract update.
-	struct ModifyContractNotification : public Notification {
+	struct ModifyContractNotification : public CloneableNotification<ModifyContractNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Contract_Modify_Notification;
@@ -77,7 +77,7 @@ namespace catapult { namespace model {
 			const CosignatoryModification* pExecutorModifications,
 			const uint8_t& verifierModificationCount,
 			const CosignatoryModification* pVerifierModifications)
-			: Notification(Notification_Type, sizeof(ModifyContractNotification))
+			: CloneableNotification(Notification_Type, sizeof(ModifyContractNotification))
 			, DurationDelta(durationDelta)
 			, Multisig(multisig)
 			, Hash(hash)

--- a/plugins/txes/contract/src/state/ReputationEntry.h
+++ b/plugins/txes/contract/src/state/ReputationEntry.h
@@ -26,6 +26,10 @@ namespace catapult { namespace state {
 	// Mixin for storing account reputation.
 	class ReputationMixin {
 	public:
+		// Creates a reputation mixin.
+		explicit ReputationMixin() : m_nPositiveInteractions(0), m_nNegativeInteractions(0)
+		{}
+
 		// Gets the number of positive interactions of the account.
 		Reputation positiveInteractions() const {
 			return m_nPositiveInteractions;

--- a/plugins/txes/lock_hash/src/model/HashLockNotifications.h
+++ b/plugins/txes/lock_hash/src/model/HashLockNotifications.h
@@ -42,7 +42,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a hash lock mosaic.
-	struct HashLockMosaicNotification : public Notification {
+	struct HashLockMosaicNotification : public CloneableNotification<HashLockMosaicNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockHash_Mosaic_Notification;
@@ -50,7 +50,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a mosaic.
 		explicit HashLockMosaicNotification(UnresolvedMosaic mosaic)
-				: Notification(Notification_Type, sizeof(HashLockMosaicNotification))
+				: CloneableNotification(Notification_Type, sizeof(HashLockMosaicNotification))
 				, Mosaic(mosaic)
 		{}
 
@@ -60,17 +60,17 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a hash lock duration.
-	struct HashLockDurationNotification : public BaseLockDurationNotification<HashLockDurationNotification> {
+	struct HashLockDurationNotification : public CloneableNotification<HashLockDurationNotification, BaseLockDurationNotification<HashLockDurationNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockHash_Hash_Duration_Notification;
 
 	public:
-		using BaseLockDurationNotification<HashLockDurationNotification>::BaseLockDurationNotification;
+		using CloneableNotification::CloneableNotification;
 	};
 
 	/// Notification of a hash lock.
-	struct HashLockNotification : public BaseLockNotification<HashLockNotification> {
+	struct HashLockNotification : public CloneableNotification<HashLockNotification, BaseLockNotification<HashLockNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockHash_Hash_Notification;
@@ -78,7 +78,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates hash lock notification around \a signer, \a mosaic, \a duration and \a hash.
 		HashLockNotification(const Key& signer, const UnresolvedMosaic& mosaic, BlockDuration duration, const Hash256& hash)
-				: BaseLockNotification(signer, mosaic, duration)
+				: CloneableNotification(signer, mosaic, duration)
 				, Hash(hash)
 		{}
 

--- a/plugins/txes/lock_secret/src/model/SecretLockNotifications.h
+++ b/plugins/txes/lock_secret/src/model/SecretLockNotifications.h
@@ -49,25 +49,25 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a secret lock duration
-	struct SecretLockDurationNotification : public BaseLockDurationNotification<SecretLockDurationNotification> {
+	struct SecretLockDurationNotification : public CloneableNotification<SecretLockDurationNotification, BaseLockDurationNotification<SecretLockDurationNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockSecret_Secret_Duration_Notification;
 
 	public:
-		using BaseLockDurationNotification<SecretLockDurationNotification>::BaseLockDurationNotification;
+		using CloneableNotification::CloneableNotification;
 	};
 
 	/// Notification of a secret lock hash algorithm.
-	struct SecretLockHashAlgorithmNotification : public Notification {
+	struct SecretLockHashAlgorithmNotification : public CloneableNotification<SecretLockHashAlgorithmNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockSecret_Hash_Algorithm_Notification;
 
 	public:
 		/// Creates secret lock hash algorithm notification around \a hashAlgorithm.
-		SecretLockHashAlgorithmNotification(LockHashAlgorithm hashAlgorithm)
-				: Notification(Notification_Type, sizeof(SecretLockHashAlgorithmNotification))
+		explicit SecretLockHashAlgorithmNotification(LockHashAlgorithm hashAlgorithm)
+				: CloneableNotification(Notification_Type, sizeof(SecretLockHashAlgorithmNotification))
 				, HashAlgorithm(hashAlgorithm)
 		{}
 
@@ -77,7 +77,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a secret lock.
-	struct SecretLockNotification : public BaseLockNotification<SecretLockNotification> {
+	struct SecretLockNotification : public CloneableNotification<SecretLockNotification, BaseLockNotification<SecretLockNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockSecret_Secret_Notification;
@@ -91,7 +91,7 @@ namespace catapult { namespace model {
 				LockHashAlgorithm hashAlgorithm,
 				const Hash256& secret,
 				const UnresolvedAddress& recipient)
-				: BaseLockNotification(signer, mosaic, duration)
+				: CloneableNotification(signer, mosaic, duration)
 				, HashAlgorithm(hashAlgorithm)
 				, Secret(secret)
 				, Recipient(recipient)
@@ -109,7 +109,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a secret and its proof.
-	struct ProofSecretNotification : public Notification {
+	struct ProofSecretNotification : public CloneableNotification<ProofSecretNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockSecret_Proof_Secret_Notification;
@@ -117,7 +117,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates proof secret notification around \a hashAlgorithm, \a secret and \a proof.
 		ProofSecretNotification(LockHashAlgorithm hashAlgorithm, const Hash256& secret, const RawBuffer& proof)
-				: Notification(Notification_Type, sizeof(ProofSecretNotification))
+				: CloneableNotification(Notification_Type, sizeof(ProofSecretNotification))
 				, HashAlgorithm(hashAlgorithm)
 				, Secret(secret)
 				, Proof(proof)
@@ -135,7 +135,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a proof publication.
-	struct ProofPublicationNotification : public Notification {
+	struct ProofPublicationNotification : public CloneableNotification<ProofPublicationNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = LockSecret_Proof_Publication_Notification;
@@ -143,7 +143,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates proof publication notification around \a signer, \a hashAlgorithm and \a secret.
 		ProofPublicationNotification(const Key& signer, LockHashAlgorithm hashAlgorithm, const Hash256& secret)
-				: Notification(Notification_Type, sizeof(ProofPublicationNotification))
+				: CloneableNotification(Notification_Type, sizeof(ProofPublicationNotification))
 				, Signer(signer)
 				, HashAlgorithm(hashAlgorithm)
 				, Secret(secret)

--- a/plugins/txes/lock_shared/src/model/LockNotifications.h
+++ b/plugins/txes/lock_shared/src/model/LockNotifications.h
@@ -26,11 +26,13 @@ namespace catapult { namespace model {
 
 	/// Base for lock duration notification.
 	template<typename TDerivedNotification>
-	struct BaseLockDurationNotification : public Notification {
+	struct BaseLockDurationNotification : public CloneableNotification<BaseLockDurationNotification<TDerivedNotification>, Notification> {
 	public:
 		/// Creates a notification around \a duration.
 		explicit BaseLockDurationNotification(BlockDuration duration)
-				: Notification(TDerivedNotification::Notification_Type, sizeof(TDerivedNotification))
+				: CloneableNotification<BaseLockDurationNotification<TDerivedNotification>, Notification>(
+						TDerivedNotification::Notification_Type,
+						sizeof(TDerivedNotification))
 				, Duration(duration)
 		{}
 
@@ -41,11 +43,13 @@ namespace catapult { namespace model {
 
 	/// Base for lock transaction notification.
 	template<typename TDerivedNotification>
-	struct BaseLockNotification : public Notification {
+	struct BaseLockNotification : CloneableNotification<BaseLockNotification<TDerivedNotification>, Notification> {
 	protected:
 		/// Creates base lock notification around \a signer, \a mosaic and \a duration.
 		BaseLockNotification(const Key& signer, const UnresolvedMosaic& mosaic, BlockDuration duration)
-				: Notification(TDerivedNotification::Notification_Type, sizeof(TDerivedNotification))
+				: CloneableNotification<BaseLockNotification<TDerivedNotification>, Notification>(
+						TDerivedNotification::Notification_Type,
+						sizeof(TDerivedNotification))
 				, Signer(signer)
 				, Mosaic(mosaic)
 				, Duration(duration)

--- a/plugins/txes/mosaic/src/model/MosaicNotifications.h
+++ b/plugins/txes/mosaic/src/model/MosaicNotifications.h
@@ -54,7 +54,7 @@ namespace catapult { namespace model {
 
 	/// Notification of mosaic properties.
 	/// \note This is required due to potentially lossy conversion from raw properties to MosaicProperties.
-	struct MosaicPropertiesNotification : public Notification {
+	struct MosaicPropertiesNotification : public CloneableNotification<MosaicPropertiesNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mosaic_Properties_Notification;
@@ -62,7 +62,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a propertiesHeader and \a pProperties.
 		explicit MosaicPropertiesNotification(const MosaicPropertiesHeader& propertiesHeader, const MosaicProperty* pProperties)
-				: Notification(Notification_Type, sizeof(MosaicPropertiesNotification))
+				: CloneableNotification(Notification_Type, sizeof(MosaicPropertiesNotification))
 				, PropertiesHeader(propertiesHeader)
 				, PropertiesPtr(pProperties)
 		{}
@@ -76,7 +76,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a mosaic definition.
-	struct MosaicDefinitionNotification : public Notification {
+	struct MosaicDefinitionNotification : public CloneableNotification<MosaicDefinitionNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mosaic_Definition_Notification;
@@ -84,7 +84,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a mosaicId and \a properties.
 		explicit MosaicDefinitionNotification(const Key& signer, MosaicId mosaicId, const MosaicProperties& properties)
-				: Notification(Notification_Type, sizeof(MosaicDefinitionNotification))
+				: CloneableNotification(Notification_Type, sizeof(MosaicDefinitionNotification))
 				, Signer(signer)
 				, MosaicId(mosaicId)
 				, Properties(properties)
@@ -102,7 +102,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a mosaic nonce and id.
-	struct MosaicNonceNotification : public Notification {
+	struct MosaicNonceNotification : public CloneableNotification<MosaicNonceNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mosaic_Nonce_Notification;
@@ -110,7 +110,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a mosaicNonce and \a mosaicId.
 		explicit MosaicNonceNotification(const Key& signer, MosaicNonce mosaicNonce, catapult::MosaicId mosaicId)
-				: Notification(Notification_Type, sizeof(MosaicNonceNotification))
+				: CloneableNotification(Notification_Type, sizeof(MosaicNonceNotification))
 				, Signer(signer)
 				, MosaicNonce(mosaicNonce)
 				, MosaicId(mosaicId)
@@ -132,7 +132,7 @@ namespace catapult { namespace model {
 	// region change
 
 	/// Notification of a mosaic supply change.
-	struct MosaicSupplyChangeNotification : public Notification {
+	struct MosaicSupplyChangeNotification : public CloneableNotification<MosaicSupplyChangeNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mosaic_Supply_Change_Notification;
@@ -140,7 +140,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a mosaicId, \a direction and \a delta.
 		MosaicSupplyChangeNotification(const Key& signer, UnresolvedMosaicId mosaicId, MosaicSupplyChangeDirection direction, Amount delta)
-				: Notification(Notification_Type, sizeof(MosaicSupplyChangeNotification))
+				: CloneableNotification(Notification_Type, sizeof(MosaicSupplyChangeNotification))
 				, Signer(signer)
 				, MosaicId(mosaicId)
 				, Direction(direction)
@@ -166,7 +166,7 @@ namespace catapult { namespace model {
 	// region rental fee
 
 	/// Notification of a mosaic rental fee.
-	struct MosaicRentalFeeNotification : public BasicBalanceNotification<MosaicRentalFeeNotification> {
+	struct MosaicRentalFeeNotification : public CloneableNotification<MosaicRentalFeeNotification, BasicBalanceNotification<MosaicRentalFeeNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mosaic_Rental_Fee_Notification;
@@ -178,7 +178,7 @@ namespace catapult { namespace model {
 				const UnresolvedAddress& recipient,
 				UnresolvedMosaicId mosaicId,
 				catapult::Amount amount)
-				: BasicBalanceNotification(sender, mosaicId, amount)
+				: CloneableNotification(sender, mosaicId, amount)
 				, Recipient(recipient)
 		{}
 

--- a/plugins/txes/multisig/src/model/MultisigNotifications.h
+++ b/plugins/txes/multisig/src/model/MultisigNotifications.h
@@ -43,7 +43,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a multisig cosigners modification.
-	struct ModifyMultisigCosignersNotification : public Notification {
+	struct ModifyMultisigCosignersNotification : public CloneableNotification<ModifyMultisigCosignersNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Multisig_Modify_Cosigners_Notification;
@@ -54,7 +54,7 @@ namespace catapult { namespace model {
 				const Key& signer,
 				uint8_t modificationsCount,
 				const CosignatoryModification* pModifications)
-				: Notification(Notification_Type, sizeof(ModifyMultisigCosignersNotification))
+				: CloneableNotification(Notification_Type, sizeof(ModifyMultisigCosignersNotification))
 				, Signer(signer)
 				, ModificationsCount(modificationsCount)
 				, ModificationsPtr(pModifications)
@@ -72,7 +72,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a new cosigner.
-	struct ModifyMultisigNewCosignerNotification : public Notification {
+	struct ModifyMultisigNewCosignerNotification : public CloneableNotification<ModifyMultisigNewCosignerNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Multisig_Modify_New_Cosigner_Notification;
@@ -80,7 +80,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a multisigAccountKey and \a cosignatoryKey.
 		explicit ModifyMultisigNewCosignerNotification(const Key& multisigAccountKey, const Key& cosignatoryKey)
-				: Notification(Notification_Type, sizeof(ModifyMultisigNewCosignerNotification))
+				: CloneableNotification(Notification_Type, sizeof(ModifyMultisigNewCosignerNotification))
 				, MultisigAccountKey(multisigAccountKey)
 				, CosignatoryKey(cosignatoryKey)
 		{}
@@ -94,7 +94,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a multisig settings modification.
-	struct ModifyMultisigSettingsNotification : public Notification {
+	struct ModifyMultisigSettingsNotification : public CloneableNotification<ModifyMultisigSettingsNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Multisig_Modify_Settings_Notification;
@@ -102,7 +102,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a minRemovalDelta and \a minApprovalDelta.
 		explicit ModifyMultisigSettingsNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta)
-				: Notification(Notification_Type, sizeof(ModifyMultisigSettingsNotification))
+				: CloneableNotification(Notification_Type, sizeof(ModifyMultisigSettingsNotification))
 				, Signer(signer)
 				, MinRemovalDelta(minRemovalDelta)
 				, MinApprovalDelta(minApprovalDelta)

--- a/plugins/txes/namespace/src/model/AliasNotifications.h
+++ b/plugins/txes/namespace/src/model/AliasNotifications.h
@@ -45,7 +45,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Base alias notification.
-	struct BaseAliasNotification : public Notification {
+	struct BaseAliasNotification : CloneableNotification<BaseAliasNotification, Notification> {
 	public:
 		/// Creates a base alias notification around \a namespaceId and \a aliasAction using \a notificationType and \a notificationSize.
 		BaseAliasNotification(
@@ -53,7 +53,7 @@ namespace catapult { namespace model {
 				size_t notificationSize,
 				catapult::NamespaceId namespaceId,
 				model::AliasAction aliasAction)
-				: Notification(notificationType, notificationSize)
+				: CloneableNotification(notificationType, notificationSize)
 				, NamespaceId(namespaceId)
 				, AliasAction(aliasAction)
 		{}
@@ -67,7 +67,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of alias owner.
-	struct AliasOwnerNotification : public BaseAliasNotification {
+	struct AliasOwnerNotification : public CloneableNotification<AliasOwnerNotification, BaseAliasNotification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Alias_Owner_Notification;
@@ -75,7 +75,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a owner, \a namespaceId and \a aliasAction.
 		AliasOwnerNotification(const Key& owner, catapult::NamespaceId namespaceId, model::AliasAction aliasAction)
-				: BaseAliasNotification(Notification_Type, sizeof(AliasOwnerNotification), namespaceId, aliasAction)
+				: CloneableNotification(Notification_Type, sizeof(AliasOwnerNotification), namespaceId, aliasAction)
 				, Owner(owner)
 		{}
 
@@ -86,7 +86,7 @@ namespace catapult { namespace model {
 
 	/// Notification of aliased data.
 	template<typename TAliasedData, NotificationType Aliased_Notification_Type>
-	struct AliasedDataNotification : public BaseAliasNotification {
+	struct AliasedDataNotification : public CloneableNotification<AliasedDataNotification<TAliasedData, Aliased_Notification_Type>, BaseAliasNotification> {
 	private:
 		using AliasedNotification = AliasedDataNotification<TAliasedData, Aliased_Notification_Type>;
 
@@ -96,7 +96,11 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a namespaceId, \a aliasAction and \a aliasedData.
 		AliasedDataNotification(catapult::NamespaceId namespaceId, model::AliasAction aliasAction, const TAliasedData& aliasedData)
-				: BaseAliasNotification(Notification_Type, sizeof(AliasedNotification), namespaceId, aliasAction)
+				: CloneableNotification<AliasedDataNotification<TAliasedData, Aliased_Notification_Type>, BaseAliasNotification>(
+						Notification_Type,
+						sizeof(AliasedNotification),
+						namespaceId,
+						aliasAction)
 				, AliasedData(aliasedData)
 		{}
 

--- a/plugins/txes/namespace/src/model/NamespaceNotifications.h
+++ b/plugins/txes/namespace/src/model/NamespaceNotifications.h
@@ -50,7 +50,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a namespace name.
-	struct NamespaceNameNotification : public Notification {
+	struct NamespaceNameNotification : public CloneableNotification<NamespaceNameNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Name_Notification;
@@ -62,7 +62,7 @@ namespace catapult { namespace model {
 				catapult::NamespaceId parentId,
 				uint8_t nameSize,
 				const uint8_t* pName)
-				: Notification(Notification_Type, sizeof(NamespaceNameNotification))
+				: CloneableNotification(Notification_Type, sizeof(NamespaceNameNotification))
 				, NamespaceId(namespaceId)
 				, ParentId(parentId)
 				, NameSize(nameSize)
@@ -84,7 +84,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a namespace registration.
-	struct NamespaceNotification : public Notification {
+	struct NamespaceNotification : public CloneableNotification<NamespaceNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Registration_Notification;
@@ -92,7 +92,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a namespaceType.
 		explicit NamespaceNotification(model::NamespaceType namespaceType)
-				: Notification(Notification_Type, sizeof(NamespaceNotification))
+				: CloneableNotification(Notification_Type, sizeof(NamespaceNotification))
 				, NamespaceType(namespaceType)
 		{}
 
@@ -102,7 +102,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a root namespace registration.
-	struct RootNamespaceNotification : public Notification {
+	struct RootNamespaceNotification : public CloneableNotification<RootNamespaceNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Root_Registration_Notification;
@@ -110,7 +110,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a namespaceId and \a duration.
 		explicit RootNamespaceNotification(const Key& signer, NamespaceId namespaceId, BlockDuration duration)
-				: Notification(Notification_Type, sizeof(RootNamespaceNotification))
+				: CloneableNotification(Notification_Type, sizeof(RootNamespaceNotification))
 				, Signer(signer)
 				, NamespaceId(namespaceId)
 				, Duration(duration)
@@ -128,7 +128,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a child namespace registration.
-	struct ChildNamespaceNotification : public Notification {
+	struct ChildNamespaceNotification : public CloneableNotification<ChildNamespaceNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Child_Registration_Notification;
@@ -136,7 +136,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a signer, \a namespaceId and \a parentId.
 		explicit ChildNamespaceNotification(const Key& signer, NamespaceId namespaceId, NamespaceId parentId)
-				: Notification(Notification_Type, sizeof(ChildNamespaceNotification))
+				: CloneableNotification(Notification_Type, sizeof(ChildNamespaceNotification))
 				, Signer(signer)
 				, NamespaceId(namespaceId)
 				, ParentId(parentId)
@@ -156,7 +156,7 @@ namespace catapult { namespace model {
 	// region rental fee
 
 	/// Notification of a namespace rental fee.
-	struct NamespaceRentalFeeNotification : public BasicBalanceNotification<NamespaceRentalFeeNotification> {
+	struct NamespaceRentalFeeNotification : public CloneableNotification<NamespaceRentalFeeNotification, BasicBalanceNotification<NamespaceRentalFeeNotification>> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Namespace_Rental_Fee_Notification;
@@ -168,7 +168,7 @@ namespace catapult { namespace model {
 				const UnresolvedAddress& recipient,
 				UnresolvedMosaicId mosaicId,
 				catapult::Amount amount)
-				: BasicBalanceNotification(sender, mosaicId, amount)
+				: CloneableNotification(sender, mosaicId, amount)
 				, Recipient(recipient)
 		{}
 

--- a/plugins/txes/property/src/model/PropertyNotifications.h
+++ b/plugins/txes/property/src/model/PropertyNotifications.h
@@ -56,7 +56,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a property type.
-	struct PropertyTypeNotification : public Notification {
+	struct PropertyTypeNotification : public CloneableNotification<PropertyTypeNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Property_Type_Notification;
@@ -64,7 +64,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a propertyType.
 		explicit PropertyTypeNotification(model::PropertyType propertyType)
-				: Notification(Notification_Type, sizeof(PropertyTypeNotification))
+				: CloneableNotification(Notification_Type, sizeof(PropertyTypeNotification))
 				, PropertyType(propertyType)
 		{}
 
@@ -75,7 +75,7 @@ namespace catapult { namespace model {
 
 	/// Notification of a property value modification.
 	template<typename TPropertyValue, NotificationType Property_Notification_Type>
-	struct ModifyPropertyValueNotification : public Notification {
+	struct ModifyPropertyValueNotification : CloneableNotification<ModifyPropertyValueNotification<TPropertyValue, Property_Notification_Type>, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Property_Notification_Type;
@@ -86,7 +86,9 @@ namespace catapult { namespace model {
 				const Key& key,
 				PropertyType propertyType,
 				const PropertyModification<TPropertyValue>& modification)
-				: Notification(Notification_Type, sizeof(ModifyPropertyValueNotification))
+				: CloneableNotification<ModifyPropertyValueNotification<TPropertyValue, Property_Notification_Type>, Notification>(
+						Notification_Type,
+						sizeof(ModifyPropertyValueNotification))
 				, Key(key)
 				, PropertyDescriptor(propertyType)
 				, Modification(modification)
@@ -113,7 +115,7 @@ namespace catapult { namespace model {
 
 	/// Notification of a property modification.
 	template<typename TPropertyValue, NotificationType Property_Notification_Type>
-	struct ModifyPropertyNotification : public Notification {
+	struct ModifyPropertyNotification : public CloneableNotification<ModifyPropertyNotification<TPropertyValue, Property_Notification_Type>, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Property_Notification_Type;
@@ -125,7 +127,9 @@ namespace catapult { namespace model {
 				PropertyType propertyType,
 				uint8_t modificationsCount,
 				const PropertyModification<TPropertyValue>* pModifications)
-				: Notification(Notification_Type, sizeof(ModifyPropertyNotification))
+				: CloneableNotification<ModifyPropertyNotification<TPropertyValue, Property_Notification_Type>, Notification>(
+						Notification_Type,
+						sizeof(ModifyPropertyNotification))
 				, Key(key)
 				, PropertyDescriptor(propertyType)
 				, ModificationsCount(modificationsCount)

--- a/plugins/txes/transfer/src/model/TransferNotifications.h
+++ b/plugins/txes/transfer/src/model/TransferNotifications.h
@@ -40,7 +40,7 @@ namespace catapult { namespace model {
 	// endregion
 
 	/// Notification of a transfer transaction with a message.
-	struct TransferMessageNotification : public Notification {
+	struct TransferMessageNotification : public CloneableNotification<TransferMessageNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Transfer_Message_Notification;
@@ -48,7 +48,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a messageSize.
 		explicit TransferMessageNotification(uint16_t messageSize)
-				: Notification(Notification_Type, sizeof(TransferMessageNotification))
+				: CloneableNotification(Notification_Type, sizeof(TransferMessageNotification))
 				, MessageSize(messageSize)
 		{}
 
@@ -58,7 +58,7 @@ namespace catapult { namespace model {
 	};
 
 	/// Notification of a transfer transaction with mosaics.
-	struct TransferMosaicsNotification : public Notification {
+	struct TransferMosaicsNotification : public CloneableNotification<TransferMosaicsNotification, Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Transfer_Mosaics_Notification;
@@ -66,7 +66,7 @@ namespace catapult { namespace model {
 	public:
 		/// Creates a notification around \a mosaicsCount and \a pMosaics.
 		explicit TransferMosaicsNotification(uint8_t mosaicsCount, const UnresolvedMosaic* pMosaics)
-				: Notification(Notification_Type, sizeof(TransferMosaicsNotification))
+				: CloneableNotification(Notification_Type, sizeof(TransferMosaicsNotification))
 				, MosaicsCount(mosaicsCount)
 				, MosaicsPtr(pMosaics)
 		{}

--- a/src/catapult/observers/ReverseNotificationObserverAdapter.cpp
+++ b/src/catapult/observers/ReverseNotificationObserverAdapter.cpp
@@ -21,6 +21,7 @@
 #include "ReverseNotificationObserverAdapter.h"
 #include "catapult/model/NotificationSubscriber.h"
 #include "catapult/model/TransactionPlugin.h"
+#include <memory>
 
 namespace catapult { namespace observers {
 
@@ -32,20 +33,18 @@ namespace catapult { namespace observers {
 					return;
 
 				// store a copy of the notification buffer
-				const auto* pData = reinterpret_cast<const uint8_t*>(&notification);
-				m_notificationBuffers.emplace_back(pData, pData + notification.Size);
+				m_notificationBuffers.emplace_back(notification.clone());
 			}
 
 		public:
 			void notifyAll(const NotificationObserver& observer, ObserverContext& context) const {
 				for (auto iter = m_notificationBuffers.crbegin(); m_notificationBuffers.crend() != iter; ++iter) {
-					const auto* pNotification = reinterpret_cast<const model::Notification*>(iter->data());
-					observer.notify(*pNotification, context);
+					observer.notify(*iter->get(), context);
 				}
 			}
 
 		private:
-			std::vector<std::vector<uint8_t>> m_notificationBuffers;
+			std::vector<std::unique_ptr<model::Notification>> m_notificationBuffers;
 		};
 	}
 

--- a/src/catapult/utils/Cloneable.h
+++ b/src/catapult/utils/Cloneable.h
@@ -1,0 +1,22 @@
+/**
+*** Copyright 2018 ProximaX Limited. All rights reserved.
+*** Use of this source code is governed by the Apache 2.0
+*** license that can be found in the LICENSE file.
+**/
+
+
+#pragma once
+#include <memory>
+
+namespace catapult { namespace utils {
+
+	/// Class that allows to override the clone method of\aBase class by \a Derived class, which return \a ReturnCloneType
+	template <class Derived, class Base, class ReturnCloneType>
+	class Cloneable : public Base {
+	public:
+		using Base::Base;
+		std::unique_ptr<ReturnCloneType> clone() const override {
+			return std::make_unique<Derived>(reinterpret_cast<Derived const&>(*this));
+		}
+	};
+}}

--- a/tests/catapult/observers/RentalFeeObserverTests.cpp
+++ b/tests/catapult/observers/RentalFeeObserverTests.cpp
@@ -34,14 +34,14 @@ namespace catapult { namespace observers {
 		constexpr auto Default_Mosaic_Id = MosaicId(345);
 		constexpr auto Default_Amount = Amount(123);
 
-		struct MockRentalFeeNotification : public model::BalanceTransferNotification {
+		struct MockRentalFeeNotification : public model::CloneableNotification<MockRentalFeeNotification, model::BalanceTransferNotification> {
 		public:
 			MockRentalFeeNotification(
 					const Key& sender,
 					const UnresolvedAddress& recipient,
 					UnresolvedMosaicId mosaicId,
 					catapult::Amount amount)
-					: BalanceTransferNotification(sender, recipient, mosaicId, amount) {
+					: CloneableNotification(sender, recipient, mosaicId, amount) {
 				// override type
 				Type = Mock_Notification;
 			}

--- a/tests/test/core/TaggedNotification.h
+++ b/tests/test/core/TaggedNotification.h
@@ -25,7 +25,7 @@ namespace catapult { namespace test {
 
 	/// A notification with a tag.
 	template<uint32_t TaggedNotificationType>
-	struct TaggedNotificationT : model::Notification {
+	struct TaggedNotificationT : model::CloneableNotification<TaggedNotificationT<TaggedNotificationType>, model::Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = static_cast<model::NotificationType>(TaggedNotificationType);
@@ -33,7 +33,9 @@ namespace catapult { namespace test {
 	public:
 		/// Creates a notification with \a tag.
 		explicit TaggedNotificationT(uint8_t tag)
-				: Notification(Notification_Type, sizeof(TaggedNotificationT))
+				: model::CloneableNotification<TaggedNotificationT<TaggedNotificationType>, model::Notification>(
+						Notification_Type,
+						sizeof(TaggedNotificationT))
 				, Tag(tag)
 		{}
 

--- a/tests/test/core/mocks/MockTransaction.h
+++ b/tests/test/core/mocks/MockTransaction.h
@@ -59,7 +59,7 @@ namespace catapult { namespace mocks {
 #undef DEFINE_MOCK_NOTIFICATION
 
 	/// Notifies the arrival of a hash.
-	struct HashNotification : public model::Notification {
+	struct HashNotification : public model::CloneableNotification<HashNotification, model::Notification> {
 	public:
 		/// Matching notification type.
 		static constexpr auto Notification_Type = Mock_Hash_Notification;
@@ -67,7 +67,7 @@ namespace catapult { namespace mocks {
 	public:
 		/// Creates a hash notification around \a hash.
 		explicit HashNotification(const Hash256& hash)
-				: model::Notification(Notification_Type, sizeof(HashNotification))
+				: CloneableNotification(Notification_Type, sizeof(HashNotification))
 				, Hash(hash)
 		{}
 

--- a/tests/test/other/MockExecutionConfiguration.h
+++ b/tests/test/other/MockExecutionConfiguration.h
@@ -51,10 +51,10 @@ namespace catapult { namespace test {
 		const Hash256 HashCopy;
 	};
 
-	struct MockNotification : public model::Notification {
+	struct MockNotification : public model::CloneableNotification<MockNotification, model::Notification> {
 	public:
 		explicit MockNotification(const Hash256& hash, size_t id)
-				: Notification(static_cast<model::NotificationType>(-1), sizeof(MockNotification))
+				: CloneableNotification(static_cast<model::NotificationType>(-1), sizeof(MockNotification))
 				, Hash(hash)
 				, Id(id)
 		{}


### PR DESCRIPTION
We had a bug during rollback mode.
If Notification's derived classes have a not primitive types like vector or unordered_map
(Or other types, which allocate memory inside on creation and free it on destruction),
it causes a not valid objects after copy them by this way:

	// store a copy of the notification buffer
	const auto* pData = reinterpret_cast<const uint8_t*>(&notification);
	m_notificationBuffers.emplace_back(pData, pData + notification.Size);

To resolve it, we created a new class Cloneable, and inherited all Notifications from this class. Now we copy object by this way:

	// store a copy of the notification buffer
	m_notificationBuffers.emplace_back(notification.clone());