### PR TITLE
PC-107 Investigate stuck of node with wrong multisig

### DIFF
--- a/src/catapult/cache/PatriciaTreeUtils.h
+++ b/src/catapult/cache/PatriciaTreeUtils.h
@@ -94,7 +94,10 @@ namespace catapult { namespace cache {
 				handleModification(pair);
 		}
 
-		for (const auto& pair : deltas.Removed) {
+		auto removed = deltas.Removed;
+		removed.insert(deltas.Uninserted.begin(), deltas.Uninserted.end());
+
+		for (const auto& pair : removed) {
 			if (needsApplication(pair.first))
 				tree.unset(pair.first);
 		}

--- a/src/catapult/deltaset/DeltaElements.h
+++ b/src/catapult/deltaset/DeltaElements.h
@@ -26,17 +26,18 @@ namespace catapult { namespace deltaset {
 	template<typename TSet>
 	struct DeltaElements {
 	public:
-		/// Creates new delta elements from \a addedElements, \a removedElements and \a copiedElements.
-		constexpr explicit DeltaElements(const TSet& addedElements, const TSet& removedElements, const TSet& copiedElements)
+		/// Creates new delta elements from \a addedElements, \a removedElements, \a uninsertedElements and \a copiedElements.
+		constexpr explicit DeltaElements(const TSet& addedElements, const TSet& removedElements, const TSet& uninsertedElements, const TSet& copiedElements)
 				: Added(addedElements)
 				, Removed(removedElements)
+				, Uninserted(uninsertedElements)
 				, Copied(copiedElements)
 		{}
 
 	public:
 		/// Returns \c true if there are any pending changes.
 		bool HasChanges() const {
-			return !(Added.empty() && Copied.empty() && Removed.empty());
+			return !(Added.empty() && Copied.empty() && Removed.empty() && Uninserted.empty());
 		}
 
 	public:
@@ -45,6 +46,9 @@ namespace catapult { namespace deltaset {
 
 		/// Removed elements.
 		const TSet& Removed;
+
+		/// Uninserted elements.
+		const TSet& Uninserted;
 
 		/// Copied elements.
 		const TSet& Copied;

--- a/tests/catapult/deltaset/DeltaElementsTests.cpp
+++ b/tests/catapult/deltaset/DeltaElementsTests.cpp
@@ -32,16 +32,16 @@ namespace catapult { namespace deltaset {
 	TEST(TEST_CLASS, HasChangesReturnsFalseWhenThereAreNoChanges) {
 		// Arrange:
 		std::set<int> empty;
-		Elements elements(empty, empty, empty);
+		Elements elements(empty, empty, empty, empty);
 
 		// Assert:
 		EXPECT_FALSE(elements.HasChanges());
 	}
 
 	namespace {
-		void AssertHasChanges(const std::set<int>& added, const std::set<int>& removed, const std::set<int>& copied) {
+		void AssertHasChanges(const std::set<int>& added, const std::set<int>& removed, const std::set<int>& uninserted, const std::set<int>& copied) {
 			// Arrange:
-			Elements elements(added, removed, copied);
+			Elements elements(added, removed, uninserted, copied);
 
 			// Assert:
 			EXPECT_TRUE(elements.HasChanges());
@@ -50,17 +50,26 @@ namespace catapult { namespace deltaset {
 
 	TEST(TEST_CLASS, HasChangesReturnsTrueWhenAnySetHasChanges) {
 		// Assert:
-		AssertHasChanges({ 1 }, {}, {});
-		AssertHasChanges({}, { 1 }, {});
-		AssertHasChanges({}, {}, { 1 });
+		AssertHasChanges({ 1 }, {}, {}, {});
+		AssertHasChanges({}, { 1 }, {}, {});
+		AssertHasChanges({}, {}, { 1 }, {});
+		AssertHasChanges({}, {}, {}, { 1 });
 
-		AssertHasChanges({ 1 }, { 1 }, {});
-		AssertHasChanges({ 1 }, {}, { 1 });
-		AssertHasChanges({}, { 1 }, { 1 });
+		AssertHasChanges({ 1 }, { 1 }, {}, {});
+		AssertHasChanges({ 1 }, {}, { 1 }, {});
+		AssertHasChanges({ 1 }, {}, {}, { 1 });
+		AssertHasChanges({ 1 }, {}, {}, { 1 });
+		AssertHasChanges({}, { 1 }, { 1 }, {});
+		AssertHasChanges({}, { 1 }, {}, { 1 });
+		AssertHasChanges({}, {}, { 1 }, { 1 });
+		AssertHasChanges({ 1 }, { 1 }, { 1 }, {});
+		AssertHasChanges({ 1 }, { 1 }, {}, { 1 });
+		AssertHasChanges({ 1 }, {}, { 1 }, { 1 });
+		AssertHasChanges({}, { 1 }, { 1 }, { 1 });
 	}
 
 	TEST(TEST_CLASS, HasChangesReturnsTrueWhenAllSetsHaveChanges) {
 		// Assert:
-		AssertHasChanges({ 1 }, { 1 }, { 1 });
+		AssertHasChanges({ 1 }, { 1 }, { 1 }, { 1 });
 	}
 }}

--- a/tests/catapult/deltaset/test/BaseSetDeltaTests.h
+++ b/tests/catapult/deltaset/test/BaseSetDeltaTests.h
@@ -686,7 +686,8 @@ namespace catapult { namespace test {
 
 			// Assert:
 			EXPECT_EQ(deltaset::RemoveResult::Uninserted, result);
-			EXPECT_EQ(0u, pDelta->generationId(TTraits::CreateKey("MyTestElement", 234)));
+			EXPECT_EQ(2u, pDelta->generationId(TTraits::CreateKey("MyTestElement", 234)));
+			EXPECT_FALSE(!!pDelta->find(TTraits::CreateKey("MyTestElement", 234)).get());
 
 			TTraits::AssertContents(*pDelta, expectedElements);
 			AssertDeltaSizes(pDelta, 3, 0, 0, 0);

--- a/tests/test/other/DeltaElementsTestUtils.h
+++ b/tests/test/other/DeltaElementsTestUtils.h
@@ -53,13 +53,16 @@ namespace catapult { namespace test {
 			/// Removed elements.
 			TSet Removed;
 
+			/// Uninserted elements.
+			TSet Uninserted;
+
 			/// Copied elements.
 			TSet Copied;
 
 		public:
 			/// Returns a delta elements around the sub sets.
 			auto deltas() const {
-				return deltaset::DeltaElements<TSet>(Added, Removed, Copied);
+				return deltaset::DeltaElements<TSet>(Added, Removed, Uninserted, Copied);
 			}
 		};
 


### PR DESCRIPTION
During sync stage we are using delta cache(for rollback and for commit modes).

If during rollback we "revert removing of MultisigEntry", we will add it to addedElements set.
If after that during commit mode we will remove this MultisigEntry again, we will remove it from addedElements.

When we calculate hash of cache, we are using partial tree. In this tree we apply add and remove operation.
But during sync we can miss remove operation. Harvester of block removed this MultisigEntry from his cache, and processed it in partial tree correct, when in sync mode we can not process remove operation and our hash will different.