### PR TITLE
PC-112 Wrong name of fields in response

### DIFF
--- a/extensions/mongo/plugins/namespace/src/AddressAliasMapper.cpp
+++ b/extensions/mongo/plugins/namespace/src/AddressAliasMapper.cpp
@@ -32,7 +32,7 @@ namespace catapult { namespace mongo { namespace plugins {
 		void StreamTransaction(bson_stream::document& builder, const TTransaction& transaction) {
 			builder
 					<< "namespaceId" << ToInt64(transaction.NamespaceId)
-					<< "action" << utils::to_underlying_type(transaction.AliasAction)
+					<< "aliasAction" << utils::to_underlying_type(transaction.AliasAction)
 					<< "address" << ToBinary(transaction.Address);
 		}
 	}

--- a/extensions/mongo/plugins/namespace/src/MosaicAliasMapper.cpp
+++ b/extensions/mongo/plugins/namespace/src/MosaicAliasMapper.cpp
@@ -32,7 +32,7 @@ namespace catapult { namespace mongo { namespace plugins {
 		void StreamTransaction(bson_stream::document& builder, const TTransaction& transaction) {
 			builder
 					<< "namespaceId" << ToInt64(transaction.NamespaceId)
-					<< "action" << utils::to_underlying_type(transaction.AliasAction)
+					<< "aliasAction" << utils::to_underlying_type(transaction.AliasAction)
 					<< "mosaicId" << ToInt64(transaction.MosaicId);
 		}
 	}

--- a/extensions/mongo/plugins/namespace/tests/AddressAliasMapperTests.cpp
+++ b/extensions/mongo/plugins/namespace/tests/AddressAliasMapperTests.cpp
@@ -54,7 +54,7 @@ namespace catapult { namespace mongo { namespace plugins {
 		// Assert:
 		EXPECT_EQ(3u, test::GetFieldCount(view));
 		EXPECT_EQ(753u, test::GetUint64(view, "namespaceId"));
-		EXPECT_EQ(model::AliasAction::Unlink, static_cast<model::AliasAction>(test::GetUint32(view, "action")));
+		EXPECT_EQ(model::AliasAction::Unlink, static_cast<model::AliasAction>(test::GetUint32(view, "aliasAction")));
 		EXPECT_EQ(transaction.Address, test::GetAddressValue(view, "address"));
 	}
 

--- a/extensions/mongo/plugins/namespace/tests/MosaicAliasMapperTests.cpp
+++ b/extensions/mongo/plugins/namespace/tests/MosaicAliasMapperTests.cpp
@@ -54,7 +54,7 @@ namespace catapult { namespace mongo { namespace plugins {
 		// Assert:
 		EXPECT_EQ(3u, test::GetFieldCount(view));
 		EXPECT_EQ(753u, test::GetUint64(view, "namespaceId"));
-		EXPECT_EQ(model::AliasAction::Unlink, static_cast<model::AliasAction>(test::GetUint32(view, "action")));
+		EXPECT_EQ(model::AliasAction::Unlink, static_cast<model::AliasAction>(test::GetUint32(view, "aliasAction")));
 		EXPECT_EQ(286u, test::GetUint64(view, "mosaicId"));
 	}
 


### PR DESCRIPTION
Changed action to aliasAction, like it expected in SDKs