### PR TITLE
[PC-186] Fix data races in tests (1)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,6 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/CMakeGlobalSettings.cmake
+++ b/CMakeGlobalSettings.cmake
@@ -89,9 +89,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	# - Wno-switch-enum: do not require enum switch statements to list every value (this setting is also incompatible with GCC warnings)
 	# - Wno-weak-vtables: vtables are emitted in all translsation units for virtual classes with no out-of-line virtual method definitions
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-		-stdlib=libc++ \
-		-Weverything \
 		-Werror \
+		-fbracket-depth=1024 \
 		-Wno-c++98-compat \
 		-Wno-c++98-compat-pedantic \
 		-Wno-disabled-macro-expansion \

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,35 +1,3 @@
-# sanitizers should be executed with gcc-7
-if(SANITIZE_ADDRESS OR SANITIZE_THREAD OR SANITIZE_UNDEFINED)
-    find_program(CMAKE_C_COMPILER gcc-7)
-    find_program(CMAKE_CXX_COMPILER g++-7)
-
-    if(NOT CMAKE_C_COMPILER)
-        message(FATAL_ERROR "gcc-7 not found")
-    endif()
-
-    if(NOT CMAKE_CXX_COMPILER)
-        message(FATAL_ERROR "g++-7 not found")
-    endif()
-
-    set(
-        CMAKE_C_COMPILER
-        "${CMAKE_C_COMPILER}"
-        CACHE
-        STRING
-        "C compiler"
-        FORCE
-    )
-
-    set(
-        CMAKE_CXX_COMPILER
-        "${CMAKE_CXX_COMPILER}"
-        CACHE
-        STRING
-        "C++ compiler"
-        FORCE
-    )
-endif()
-
 # only one of them can be enabled simultaneously
 if(SANITIZE_ADDRESS)
     message(STATUS "SANITIZE_ADDRESS enabled")

--- a/extensions/partialtransaction/tests/chain/PtUpdaterTests.cpp
+++ b/extensions/partialtransaction/tests/chain/PtUpdaterTests.cpp
@@ -309,7 +309,7 @@ namespace catapult { namespace chain {
 
 			mutable utils::SpinLock m_lock;
 			mutable size_t m_numValidatePartialCalls;
-			mutable size_t m_numValidateCosignersCalls;
+			mutable std::atomic<size_t> m_numValidateCosignersCalls;
 			mutable size_t m_numLastCosigners;
 			mutable std::vector<model::UniqueEntityPtr<model::Transaction>> m_transactions;
 			mutable std::vector<Hash256> m_transactionHashes;

--- a/extensions/zeromq/tests/test/ZeroMqTestUtils.cpp
+++ b/extensions/zeromq/tests/test/ZeroMqTestUtils.cpp
@@ -130,7 +130,7 @@ namespace catapult { namespace test {
 			const zmq::multipart_t& message,
 			const std::vector<uint8_t>& topic,
 			const model::TransactionInfo& transactionInfo,
-			Height height) {
+			const Height& height) {
 		ASSERT_EQ(5u, message.size());
 
 		const auto& transaction = *transactionInfo.pEntity;
@@ -177,7 +177,7 @@ namespace catapult { namespace test {
 
 		// Assert: each address should get a message
 		auto addressesCopy = addresses;
-		for (auto i = 0u; i < addresses.size(); ++i) {
+		for (size_t i = 0u; i < addresses.size(); ++i) {
 			ZmqReceive(message, zmqSocket);
 
 			const auto* pAddressData = reinterpret_cast<const uint8_t*>(message[0].data()) + 1;

--- a/extensions/zeromq/tests/test/ZeroMqTestUtils.h
+++ b/extensions/zeromq/tests/test/ZeroMqTestUtils.h
@@ -86,7 +86,7 @@ namespace catapult { namespace test {
 			const zmq::multipart_t& message,
 			const std::vector<uint8_t>& topic,
 			const model::TransactionInfo& transactionInfo,
-			Height height);
+			const Height& height);
 
 	/// Asserts that the given \a message has \a topic as first part and matches the data in \a hash.
 	void AssertTransactionHashMessage(const zmq::multipart_t& message, const std::vector<uint8_t>& topic, const Hash256& hash);

--- a/src/catapult/config_holder/BlockchainConfigurationHolder.cpp
+++ b/src/catapult/config_holder/BlockchainConfigurationHolder.cpp
@@ -98,7 +98,7 @@ namespace catapult { namespace config {
 	}
 
 	BlockchainConfiguration& BlockchainConfigurationHolder::Config() {
-		return Config(m_pCache != NULL ? m_pCache->configHeight() : Height(0));
+		return Config(m_pCache != nullptr ? m_pCache->configHeight() : Height(0));
 	}
 
 	BlockchainConfiguration& BlockchainConfigurationHolder::ConfigAtHeightOrLatest(const Height& height) {

--- a/src/catapult/config_holder/ConfigTreeCache.cpp
+++ b/src/catapult/config_holder/ConfigTreeCache.cpp
@@ -1,0 +1,71 @@
+/**
+*** Copyright 2019 ProximaX Limited. All rights reserved.
+*** Use of this source code is governed by the Apache 2.0
+*** license that can be found in the LICENSE file.
+**/
+
+#include "ConfigTreeCache.h"
+
+namespace catapult { namespace config {
+
+	bool ConfigTreeCache::contains(const Height& height) const {
+		return m_references.count(height) > 0 || m_configs.count(height) > 0;
+	}
+
+	BlockchainConfiguration& ConfigTreeCache::insert(const Height& height, const BlockchainConfiguration& config) {
+		if (m_configs.count(height))
+			CATAPULT_THROW_INVALID_ARGUMENT_1("duplicate config at height", height);
+
+		m_configs.emplace(height, ConfigRoot { config, {} });
+
+		return m_configs.at(height).Config;
+	}
+
+	BlockchainConfiguration& ConfigTreeCache::insertRef(const Height& refHeight, const Height& configHeight) {
+		if (refHeight == configHeight)
+			CATAPULT_THROW_INVALID_ARGUMENT_1("reference is not allowed at the same height", configHeight);
+
+		auto iter = m_configs.find(configHeight);
+		if (iter == m_configs.end())
+			CATAPULT_THROW_INVALID_ARGUMENT_1(
+					"failed to insert reference because config doesn't exist at height", configHeight);
+
+		if (m_references.count(refHeight))
+			CATAPULT_THROW_INVALID_ARGUMENT_1(
+					"failed to insert reference because reference already exist at height", refHeight);
+
+		auto& root = iter->second;
+		cleanupRefs(root);
+		m_references.emplace(refHeight, ConfigLeaf { root });
+		root.Children.insert(refHeight);
+
+		return iter->second.Config;
+	}
+
+	void ConfigTreeCache::erase(const Height& height) {
+		auto iterRef = m_references.find(height);
+		if (iterRef != m_references.end()) {
+			iterRef->second.Parent.Children.erase(height);
+			m_references.erase(iterRef);
+			return;
+		}
+
+		auto iter = m_configs.find(height);
+		if (iter != m_configs.end()) {
+			cleanupRefs(iter->second, 0);
+			m_configs.erase(iter);
+		}
+	}
+
+	BlockchainConfiguration& ConfigTreeCache::get(const Height& height) {
+		auto iterRef = m_references.find(height);
+		if (iterRef != m_references.end())
+			return iterRef->second.Parent.Config;
+
+		auto iter = m_configs.find(height);
+		if (iter != m_configs.end())
+			return iter->second.Config;
+
+		CATAPULT_THROW_INVALID_ARGUMENT_1("config doesn't exist at height", height);
+	}
+}} // namespace catapult::config

--- a/src/catapult/config_holder/ConfigTreeCache.h
+++ b/src/catapult/config_holder/ConfigTreeCache.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "catapult/config/BlockchainConfiguration.h"
 #include <set>
+#include <mutex>
 
 namespace catapult { namespace config {
 
@@ -25,64 +26,15 @@ namespace catapult { namespace config {
 		explicit ConfigTreeCache() = default;
 
 	public:
-		bool contains(const Height& height) const {
-			return m_references.count(height) > 0 || m_configs.count(height) > 0;
-		}
+		bool contains(const Height& height) const;
 
-		BlockchainConfiguration& insert(const Height& height, const BlockchainConfiguration& config) {
-			if (m_configs.count(height))
-				CATAPULT_THROW_INVALID_ARGUMENT_1("duplicate config at height", height);
+		BlockchainConfiguration& insert(const Height& height, const BlockchainConfiguration& config);
 
-			m_configs.emplace(height, ConfigRoot{ config , {} });
+		BlockchainConfiguration& insertRef(const Height& refHeight, const Height& configHeight);
 
-			return m_configs.at(height).Config;
-		}
+		void erase(const Height& height);
 
-		BlockchainConfiguration& insertRef(const Height& refHeight, const Height& configHeight) {
-			if (refHeight == configHeight)
-				CATAPULT_THROW_INVALID_ARGUMENT_1("reference is not allowed at the same height", configHeight);
-
-			auto iter = m_configs.find(configHeight);
-			if (iter == m_configs.end())
-				CATAPULT_THROW_INVALID_ARGUMENT_1("failed to insert reference because config doesn't exist at height", configHeight);
-
-			if (m_references.count(refHeight))
-				CATAPULT_THROW_INVALID_ARGUMENT_1("failed to insert reference because reference already exist at height", refHeight);
-
-			auto& root = iter->second;
-			cleanupRefs(root);
-			m_references.emplace(refHeight, ConfigLeaf{ root });
-			root.Children.insert(refHeight);
-
-			return iter->second.Config;
-		}
-
-		void erase(const Height& height) {
-			auto iterRef = m_references.find(height);
-			if (iterRef != m_references.end()) {
-				iterRef->second.Parent.Children.erase(height);
-				m_references.erase(iterRef);
-				return;
-			}
-
-			auto iter = m_configs.find(height);
-			if (iter != m_configs.end()) {
-				cleanupRefs(iter->second, 0);
-				m_configs.erase(iter);
-			}
-		}
-
-		BlockchainConfiguration& get(const Height& height) {
-			auto iterRef = m_references.find(height);
-			if (iterRef != m_references.end())
-				return iterRef->second.Parent.Config;
-
-			auto iter = m_configs.find(height);
-			if (iter != m_configs.end())
-				return iter->second.Config;
-
-			CATAPULT_THROW_INVALID_ARGUMENT_1("config doesn't exist at height", height);
-		}
+		BlockchainConfiguration& get(const Height& height);
 
 	private:
 		void cleanupRefs(ConfigRoot& root) {

--- a/src/catapult/ionet/SocketReader.cpp
+++ b/src/catapult/ionet/SocketReader.cpp
@@ -129,7 +129,7 @@ namespace catapult { namespace ionet {
 
 			// these will be synchronized because they are modified by callbacks that execute on the
 			// underlying socket's strand
-			size_t m_numOutstandingOperations;
+			std::atomic<size_t> m_numOutstandingOperations;
 			size_t m_state;
 		};
 

--- a/src/catapult/thread/MultiServicePool.h
+++ b/src/catapult/thread/MultiServicePool.h
@@ -252,7 +252,7 @@ namespace catapult { namespace thread {
 		std::string m_name;
 		IsolatedPoolMode m_isolatedPoolMode;
 		size_t m_numTotalIsolatedPoolThreads;
-		size_t m_numServiceGroups;
+		std::atomic<size_t> m_numServiceGroups;
 		std::shared_ptr<thread::IoThreadPool> m_pPool;
 		std::vector<std::shared_ptr<ServiceGroup>> m_serviceGroups;
 		std::vector<action> m_shutdownFunctions;

--- a/tests/catapult/disruptor/ConsumerDispatcherTests.cpp
+++ b/tests/catapult/disruptor/ConsumerDispatcherTests.cpp
@@ -340,7 +340,7 @@ namespace catapult { namespace disruptor {
 		auto expectedHeights = GetExpectedHeights(ranges);
 
 		std::vector<Heights> collectedHeights;
-		auto numInspectorCalls = 0u;
+		std::atomic<size_t> numInspectorCalls = 0u;
 		ConsumerDispatcher dispatcher(
 				Test_Dispatcher_Options,
 				{ CreateConsumer(collectedHeights) },
@@ -348,7 +348,7 @@ namespace catapult { namespace disruptor {
 
 		// Act: push single element
 		ProcessAll(dispatcher, std::move(ranges));
-		WAIT_FOR_ONE_EXPR(numInspectorCalls);
+		WAIT_FOR_ONE_EXPR((size_t)numInspectorCalls);
 		// - pause is here, to let both the consumer and inspector continue for a bit more,
 		//   in case if it would still be running and there'd be bug in implementation
 		test::Pause();

--- a/tests/catapult/thread/MultiServicePoolTests.cpp
+++ b/tests/catapult/thread/MultiServicePoolTests.cpp
@@ -68,6 +68,7 @@ namespace catapult { namespace thread {
 
 		public:
 			void shutdown() {
+				std::lock_guard<std::mutex> lock(m_mutex);
 				// since clearing dependencies unblocks shutdown of pool, first push shutdown id into vector
 				m_shutdownIds.push_back(m_id);
 				m_dependencies.clear();
@@ -78,6 +79,7 @@ namespace catapult { namespace thread {
 			}
 
 		private:
+			std::mutex m_mutex;
 			std::string m_threadPoolTag;
 			size_t m_id;
 			ShutdownIds& m_shutdownIds;

--- a/tests/catapult/thread/TimedCallbackTests.cpp
+++ b/tests/catapult/thread/TimedCallbackTests.cpp
@@ -49,7 +49,7 @@ namespace catapult { namespace thread {
 #undef ENUM_LIST
 
 		struct TimedCallbackResult {
-			TimedCallbackResultCode Code;
+			std::atomic<TimedCallbackResultCode> Code;
 			std::atomic<uint32_t> NumCallbackCalls;
 			std::atomic<uint32_t> NumTimeoutHandlerCalls;
 

--- a/tests/catapult/validators/ValidatorContextTests.cpp
+++ b/tests/catapult/validators/ValidatorContextTests.cpp
@@ -37,7 +37,7 @@ namespace catapult { namespace validators {
 
 	TEST(TEST_CLASS, CanCreateValidatorContextAroundHeightAndNetworkAndCache) {
 		// Act:
-		auto networkInfo = model::NetworkInfo({});
+		model::NetworkInfo networkInfo{};
 		auto cache = test::CreateEmptyCatapultCache();
 		auto cacheView = cache.createView();
 		auto readOnlyCache = cacheView.toReadOnly();

--- a/tests/test/nodeps/LockTestUtils.h
+++ b/tests/test/nodeps/LockTestUtils.h
@@ -198,7 +198,7 @@ namespace catapult { namespace test {
 	template<typename TAcquireFirstLockFunc, typename TAcquireSecondLockFunc>
 	void AssertExclusiveLocks(TAcquireFirstLockFunc acquireFirstLock, TAcquireSecondLockFunc acquireSecondLock) {
 		// Arrange: get the first lock
-		int flag = 0;
+		std::atomic<int> flag = 0;
 		{
 			auto lock1 = acquireFirstLock();
 

--- a/tests/test/nodeps/Random.cpp
+++ b/tests/test/nodeps/Random.cpp
@@ -20,6 +20,7 @@
 
 #include "Random.h"
 #include <random>
+#include <mutex>
 
 namespace catapult { namespace test {
 
@@ -52,10 +53,14 @@ namespace catapult { namespace test {
 			}
 
 			uint64_t operator()() {
+				std::lock_guard<std::mutex> lock(m_mutex);
+				// this call mutates generator, so
+				// we need to have serialized access to operator()
 				return m_gen();
 			}
 
 		private:
+			std::mutex m_mutex;
 			std::mt19937_64 m_gen;
 		};
 	}

--- a/tests/test/other/MockExecutionConfiguration.h
+++ b/tests/test/other/MockExecutionConfiguration.h
@@ -250,7 +250,7 @@ namespace catapult { namespace test {
 				, pValidator(std::make_shared<MockAggregateNotificationValidator>())
 				, pNotificationPublisher(std::make_shared<MockNotificationPublisher>()) {
 			Config.NetworkIdentifier = Mock_Execution_Configuration_Network_Identifier;
-			Config.NetworkInfoSupplier = [](const Height&) { return model::NetworkInfo( {} ); };
+			Config.NetworkInfoSupplier = [](const Height&) { return model::NetworkInfo(); };
 			Config.pObserver = pObserver;
 			Config.pValidator = pValidator;
 			Config.pNotificationPublisher = pNotificationPublisher;
@@ -277,8 +277,8 @@ namespace catapult { namespace test {
 		static void AssertObserverContexts(
 				const MockAggregateNotificationObserver& observer,
 				size_t numInitialCacheDifficultyInfos,
-				Height expectedHeight,
-				model::ImportanceHeight expectedImportanceHeight,
+				const Height& expectedHeight,
+				const model::ImportanceHeight& expectedImportanceHeight,
 				const predicate<size_t>& isRollbackExecution) {
 			// Assert:
 			size_t i = 0;
@@ -309,8 +309,8 @@ namespace catapult { namespace test {
 		static void AssertValidatorContexts(
 				const MockAggregateNotificationValidator& validator,
 				const std::vector<size_t>& expectedNumDifficultyInfos,
-				Height expectedHeight,
-				Timestamp expectedBlockTime) {
+				const Height& expectedHeight,
+				const Timestamp& expectedBlockTime) {
 			// Assert:
 			ASSERT_EQ(expectedNumDifficultyInfos.size(), validator.params().size());
 

--- a/tests/test/other/mocks/MockNodeSubscriber.h
+++ b/tests/test/other/mocks/MockNodeSubscriber.h
@@ -47,7 +47,7 @@ namespace catapult { namespace mocks {
 		/// Creates params around \a identityKey and \a serviceId.
 		explicit NodeSubscriberIncomingNodeParams(const Key& identityKey, ionet::ServiceIdentifier serviceId)
 				: IdentityKey(identityKey)
-				, ServiceId(serviceId)
+				, ServiceId(std::move(serviceId))
 		{}
 
 	public:

--- a/tests/test/other/mocks/MockNotificationValidator.h
+++ b/tests/test/other/mocks/MockNotificationValidator.h
@@ -52,6 +52,7 @@ namespace catapult { namespace mocks {
 	public:
 		/// Sets the result of validate to \a result.
 		void setResult(validators::ValidationResult result) {
+			std::lock_guard<std::mutex> lock(m_mutex);
 			m_result = result;
 		}
 
@@ -63,6 +64,7 @@ namespace catapult { namespace mocks {
 		}
 
 	private:
+		mutable std::mutex m_mutex;
 		validators::ValidationResult m_result;
 		bool m_triggerOnSpecificType;
 		model::NotificationType m_triggerType;


### PR DESCRIPTION
Thread Sanitizer found issues in these tests:
```
          2 - tests.catapult.cache (Failed)
          8 - tests.catapult.config_holder (Failed)
         12 - tests.catapult.disruptor (Failed)
         16 - tests.catapult.ionet (Failed)
         26 - tests.catapult.thread (Failed)
         31 - tests.catapult.int.node.stress (Failed)
         32 - tests.catapult.int.stress (Failed)
         82 - tests.catapult.nodediscovery (Failed)
         84 - tests.catapult.partialtransaction (Failed)
         86 - tests.catapult.sync (Failed)
         88 - tests.catapult.timesync (Failed)
         91 - tests.catapult.zeromq (Failed)
```

After this PR still failing tests:
```
          8 - tests.catapult.config_holder (Failed)
         12 - tests.catapult.disruptor (Failed)
         31 - tests.catapult.int.node.stress (Failed)
         82 - tests.catapult.nodediscovery (Failed)
         86 - tests.catapult.sync (Failed)
         91 - tests.catapult.zeromq (Failed)
```

Most issues are from tests - for example, 2 or more threads can read/write to the same std::map concurrently (tests.catapult.disruptor), etc.