### PR TITLE
[PC-177] Fixed unconfirmed transaction synchronization.

### DIFF
--- a/extensions/networkheight/src/NetworkHeightService.cpp
+++ b/extensions/networkheight/src/NetworkHeightService.cpp
@@ -78,7 +78,10 @@ namespace catapult { namespace networkheight {
 				// if the local node's chain is too far behind, some operations like harvesting or
 				// processing of pushed elements should not be allowed
 				// for a public network this should always return true since an evil node could supply a fake chain height
-				state.hooks().setChainSyncedPredicate([&storage = state.storage(), &networkChainHeight = *pNetworkChainHeight]() {
+				state.hooks().setChainSyncedPredicate([&storage = state.storage(), &networkChainHeight = *pNetworkChainHeight,
+						networkIdentifier = state.config().Immutable.NetworkIdentifier]() {
+					if (model::NetworkIdentifier::Public == networkIdentifier)
+						return true;
 					auto storageView = storage.view();
 					return networkChainHeight.load() < storageView.chainHeight().unwrap() + 4;
 				});

--- a/plugins/txes/config/tests/validators/NetworkConfigValidatorTests.cpp
+++ b/plugins/txes/config/tests/validators/NetworkConfigValidatorTests.cpp
@@ -50,6 +50,7 @@ namespace catapult { namespace validators {
 			"\n"
 			"blockPruneInterval = 360\n"
 			"maxTransactionsPerBlock = 200'000\n\n"
+			"enableUnconfirmedTransactionMinFeeValidation = true\n\n"
 		};
 
 		std::string pluginConfigs{

--- a/resources/config-network.properties
+++ b/resources/config-network.properties
@@ -26,6 +26,8 @@ harvestBeneficiaryPercentage = 10
 blockPruneInterval = 360
 maxTransactionsPerBlock = 200'000
 
+enableUnconfirmedTransactionMinFeeValidation = true
+
 [plugin:catapult.plugins.accountlink]
 
 dummy = to trigger plugin load

--- a/scripts/bootstrap/ruby/catapult-templates/api_node/resources/config-network.properties.mt
+++ b/scripts/bootstrap/ruby/catapult-templates/api_node/resources/config-network.properties.mt
@@ -26,6 +26,8 @@ harvestBeneficiaryPercentage = 10
 blockPruneInterval = 360
 maxTransactionsPerBlock = 200'000
 
+enableUnconfirmedTransactionMinFeeValidation = true
+
 [plugin:catapult.plugins.accountlink]
 dummy = to trigger plugin load
 

--- a/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/config-network.properties.mt
+++ b/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/config-network.properties.mt
@@ -26,6 +26,8 @@ harvestBeneficiaryPercentage = 10
 blockPruneInterval = 360
 maxTransactionsPerBlock = 200'000
 
+enableUnconfirmedTransactionMinFeeValidation = true
+
 [plugin:catapult.plugins.accountlink]
 dummy = to trigger plugin load
 

--- a/src/catapult/chain/ExecutionConfiguration.h
+++ b/src/catapult/chain/ExecutionConfiguration.h
@@ -30,6 +30,7 @@ namespace catapult { namespace chain {
 	struct ExecutionConfiguration {
 	private:
 		using NetworkInfoSupplierFunc = std::function<model::NetworkInfo (const Height& height)>;
+		using MinFeeMultiplierSupplierFunc = std::function<BlockFeeMultiplier (const Height&)>;
 		using ObserverPointer = std::shared_ptr<const observers::AggregateNotificationObserver>;
 		using ValidatorPointer = std::shared_ptr<const validators::stateful::AggregateNotificationValidator>;
 		using PublisherPointer = std::shared_ptr<const model::NotificationPublisher>;
@@ -41,6 +42,9 @@ namespace catapult { namespace chain {
 
 		/// Network info supplier.
 		NetworkInfoSupplierFunc NetworkInfoSupplier;
+
+		/// Min transaction fee multiplier supplier.
+		MinFeeMultiplierSupplierFunc MinFeeMultiplierSupplier;
 
 		/// Observer.
 		ObserverPointer pObserver;

--- a/src/catapult/chain/UtSynchronizer.cpp
+++ b/src/catapult/chain/UtSynchronizer.cpp
@@ -32,17 +32,17 @@ namespace catapult { namespace chain {
 
 		public:
 			explicit UtTraits(
-					BlockFeeMultiplier minFeeMultiplier,
+					const MinFeeMultiplierSupplier& minFeeMultiplierSupplier,
 					const ShortHashesSupplier& shortHashesSupplier,
 					const handlers::TransactionRangeHandler& transactionRangeConsumer)
-					: m_minFeeMultiplier(minFeeMultiplier)
+					: m_minFeeMultiplierSupplier(minFeeMultiplierSupplier)
 					, m_shortHashesSupplier(shortHashesSupplier)
 					, m_transactionRangeConsumer(transactionRangeConsumer)
 			{}
 
 		public:
 			thread::future<model::TransactionRange> apiCall(const RemoteApiType& api) const {
-				return api.unconfirmedTransactions(m_minFeeMultiplier, m_shortHashesSupplier());
+				return api.unconfirmedTransactions(m_minFeeMultiplierSupplier(), m_shortHashesSupplier());
 			}
 
 			void consume(model::TransactionRange&& range, const Key& sourcePublicKey) const {
@@ -50,17 +50,17 @@ namespace catapult { namespace chain {
 			}
 
 		private:
-			BlockFeeMultiplier m_minFeeMultiplier;
+			MinFeeMultiplierSupplier m_minFeeMultiplierSupplier;
 			ShortHashesSupplier m_shortHashesSupplier;
 			handlers::TransactionRangeHandler m_transactionRangeConsumer;
 		};
 	}
 
 	RemoteNodeSynchronizer<api::RemoteTransactionApi> CreateUtSynchronizer(
-			BlockFeeMultiplier minFeeMultiplier,
+			const MinFeeMultiplierSupplier& minFeeMultiplierSupplier,
 			const ShortHashesSupplier& shortHashesSupplier,
 			const handlers::TransactionRangeHandler& transactionRangeConsumer) {
-		auto traits = UtTraits(minFeeMultiplier, shortHashesSupplier, transactionRangeConsumer);
+		auto traits = UtTraits(minFeeMultiplierSupplier, shortHashesSupplier, transactionRangeConsumer);
 		auto pSynchronizer = std::make_shared<EntitiesSynchronizer<UtTraits>>(std::move(traits));
 		return CreateRemoteNodeSynchronizer(pSynchronizer);
 	}

--- a/src/catapult/chain/UtSynchronizer.h
+++ b/src/catapult/chain/UtSynchronizer.h
@@ -30,10 +30,13 @@ namespace catapult { namespace chain {
 	/// Function signature for supplying a range of short hashes.
 	using ShortHashesSupplier = supplier<model::ShortHashRange>;
 
+	/// Function signature for supplying min transaction fee multiplier.
+	using MinFeeMultiplierSupplier = supplier<BlockFeeMultiplier>;
+
 	/// Creates an unconfirmed transactions synchronizer around the specified short hashes supplier (\a shortHashesSupplier)
-	/// and transaction range consumer (\a transactionRangeConsumer) for transactions with fee multipliers at least \a minFeeMultiplier.
+	/// and transaction range consumer (\a transactionRangeConsumer) for transactions with fee multipliers at least provided by \a minFeeMultiplierSupplier.
 	RemoteNodeSynchronizer<api::RemoteTransactionApi> CreateUtSynchronizer(
-			BlockFeeMultiplier minFeeMultiplier,
-			const ShortHashesSupplier& shortHashesSupplier,
-			const handlers::TransactionRangeHandler& transactionRangeConsumer);
+		const MinFeeMultiplierSupplier& minFeeMultiplierSupplier,
+		const ShortHashesSupplier& shortHashesSupplier,
+		const handlers::TransactionRangeHandler& transactionRangeConsumer);
 }}

--- a/src/catapult/chain/UtUpdater.cpp
+++ b/src/catapult/chain/UtUpdater.cpp
@@ -124,6 +124,7 @@ namespace catapult { namespace chain {
 			auto effectiveHeight = m_detachedCatapultCache.height() + Height(1);
 			auto networkIdentifier = m_executionConfig.NetworkIdentifier;
 			const auto& network = m_executionConfig.NetworkInfoSupplier(effectiveHeight);
+			auto minFeeMultiplier = m_executionConfig.MinFeeMultiplierSupplier(effectiveHeight);
 			auto resolverContext = m_executionConfig.ResolverContextFactory(readOnlyCache);
 			auto validatorContext = ValidatorContext(effectiveHeight, currentTime, networkIdentifier, network, resolverContext, readOnlyCache);
 
@@ -138,7 +139,7 @@ namespace catapult { namespace chain {
 				if (!filter(utInfo))
 					continue;
 
-				auto minTransactionFee = model::CalculateTransactionFee(m_config.MinFeeMultiplier, entity, m_config.FeeInterest, m_config.FeeInterestDenominator);
+				auto minTransactionFee = model::CalculateTransactionFee(minFeeMultiplier, entity, m_config.FeeInterest, m_config.FeeInterestDenominator);
 				if (entity.MaxFee < minTransactionFee) {
 					// don't log reverted transactions that could have been included by harvester with lower min fee multiplier
 					if (TransactionSource::New == transactionSource) {

--- a/src/catapult/config/BlockchainConfiguration.cpp
+++ b/src/catapult/config/BlockchainConfiguration.cpp
@@ -92,4 +92,8 @@ namespace catapult { namespace config {
 
 		return ionet::Node(identityKey, endpoint, metadata);
 	}
+
+	BlockFeeMultiplier GetMinFeeMultiplier(const BlockchainConfiguration& config) {
+		return config.Network.EnableUnconfirmedTransactionMinFeeValidation ? config.Node.MinFeeMultiplier : BlockFeeMultiplier{0};
+	}
 }}

--- a/src/catapult/config/BlockchainConfiguration.h
+++ b/src/catapult/config/BlockchainConfiguration.h
@@ -81,4 +81,7 @@ namespace catapult { namespace config {
 
 	/// Extracts a node representing the local node from \a config.
 	ionet::Node ToLocalNode(const BlockchainConfiguration& config);
+
+	/// Gets min transaction fee multiplier.
+	BlockFeeMultiplier GetMinFeeMultiplier(const BlockchainConfiguration& config);
 }}

--- a/src/catapult/extensions/ExecutionConfigurationFactory.cpp
+++ b/src/catapult/extensions/ExecutionConfigurationFactory.cpp
@@ -28,6 +28,7 @@ namespace catapult { namespace extensions {
 		chain::ExecutionConfiguration executionConfig;
 		executionConfig.NetworkIdentifier = pluginManager.immutableConfig().NetworkIdentifier;
 		executionConfig.NetworkInfoSupplier = [&pluginManager](const Height& height) { return pluginManager.config(height).Info; };
+		executionConfig.MinFeeMultiplierSupplier = [&pluginManager](const Height& height) { return config::GetMinFeeMultiplier(pluginManager.configHolder()->Config(height)); };
 		executionConfig.pObserver = pluginManager.createObserver();
 		executionConfig.pValidator = pluginManager.createStatefulValidator();
 		executionConfig.pNotificationPublisher = pluginManager.createNotificationPublisher();

--- a/src/catapult/local/server/LocalNode.cpp
+++ b/src/catapult/local/server/LocalNode.cpp
@@ -109,6 +109,9 @@ namespace catapult { namespace local {
 				auto peersFile = boost::filesystem::path(m_pBootstrapper->resourcesPath()) / "peers-p2p.json";
 				if (boost::filesystem::exists(peersFile))
 					AddStaticNodesFromPath(*m_pBootstrapper, peersFile.generic_string());
+				peersFile = boost::filesystem::path(m_pBootstrapper->resourcesPath()) / "peers-api.json";
+				if (boost::filesystem::exists(peersFile))
+					AddStaticNodesFromPath(*m_pBootstrapper, peersFile.generic_string());
 				SeedNodeContainer(m_nodes, *m_pBootstrapper);
 
 				CATAPULT_LOG(debug) << "booting extension services";

--- a/src/catapult/model/NetworkConfiguration.cpp
+++ b/src/catapult/model/NetworkConfiguration.cpp
@@ -70,6 +70,8 @@ namespace catapult { namespace model {
 		LOAD_CHAIN_PROPERTY(BlockPruneInterval);
 		LOAD_CHAIN_PROPERTY(MaxTransactionsPerBlock);
 
+		LOAD_CHAIN_PROPERTY(EnableUnconfirmedTransactionMinFeeValidation);
+
 #undef LOAD_CHAIN_PROPERTY
 
 		size_t numPluginProperties = 0;
@@ -87,7 +89,7 @@ namespace catapult { namespace model {
 			numPluginProperties += iter->second.size();
 		}
 
-		utils::VerifyBagSizeLte(bag, 16 + numPluginProperties);
+		utils::VerifyBagSizeLte(bag, 17 + numPluginProperties);
 		return config;
 	}
 

--- a/src/catapult/model/NetworkConfiguration.h
+++ b/src/catapult/model/NetworkConfiguration.h
@@ -87,6 +87,10 @@ namespace catapult { namespace model {
 		/// Maximum number of transactions per block.
 		uint32_t MaxTransactionsPerBlock;
 
+		/// Allows validation of unconfirmed transactions before including it into UT cache
+		/// that transaction fee is not less than the minimum calculated with minFeeMultiplier.
+		bool EnableUnconfirmedTransactionMinFeeValidation;
+
 		/// Unparsed map of plugin configuration bags.
 		std::unordered_map<std::string, utils::ConfigurationBag> Plugins;
 

--- a/src/catapult/net/PacketWriters.cpp
+++ b/src/catapult/net/PacketWriters.cpp
@@ -25,7 +25,6 @@
 #include "catapult/ionet/PacketSocket.h"
 #include "catapult/thread/IoThreadPool.h"
 #include "catapult/thread/TimedCallback.h"
-#include "catapult/utils/HexFormatter.h"
 #include "catapult/utils/ModificationSafeIterableContainer.h"
 #include "catapult/utils/SpinLock.h"
 #include "catapult/utils/ThrottleLogger.h"

--- a/tests/catapult/chain/UtSynchronizerTests.cpp
+++ b/tests/catapult/chain/UtSynchronizerTests.cpp
@@ -86,7 +86,7 @@ namespace catapult { namespace chain {
 			static auto CreateSynchronizer(
 					const ShortHashesSupplier& shortHashesSupplier,
 					const handlers::TransactionRangeHandler& transactionRangeConsumer) {
-				return CreateUtSynchronizer(BlockFeeMultiplier(17), shortHashesSupplier, transactionRangeConsumer);
+				return CreateUtSynchronizer([]() { return BlockFeeMultiplier(17); }, shortHashesSupplier, transactionRangeConsumer);
 			}
 		};
 	}

--- a/tests/catapult/chain/UtUpdaterTests.cpp
+++ b/tests/catapult/chain/UtUpdaterTests.cpp
@@ -123,7 +123,8 @@ namespace catapult { namespace chain {
 			explicit UpdaterTestContext(
 					ThrottleMode throttleMode = ThrottleMode::Off,
 					BlockFeeMultiplier minFeeMultiplier = BlockFeeMultiplier())
-					: m_cache(CreateCacheWithDefaultHeight())
+					: m_executionConfig(minFeeMultiplier)
+					, m_cache(CreateCacheWithDefaultHeight())
 					, m_transactionsCache(cache::MemoryCacheOptions(1024, 1000))
 					, m_updater(
 							m_transactionsCache,

--- a/tests/catapult/config/BlockchainConfigurationTests.cpp
+++ b/tests/catapult/config/BlockchainConfigurationTests.cpp
@@ -29,7 +29,7 @@
 
 namespace catapult { namespace config {
 
-#define TEST_CLASS NetworkConfigurationTests
+#define TEST_CLASS BlockchainConfigurationTests
 
 	// region BlockchainConfiguration file io
 
@@ -88,6 +88,8 @@ namespace catapult { namespace config {
 
 			EXPECT_EQ(360u, config.BlockPruneInterval);
 			EXPECT_EQ(200'000u, config.MaxTransactionsPerBlock);
+
+			EXPECT_EQ(true, config.EnableUnconfirmedTransactionMinFeeValidation);
 
 			EXPECT_FALSE(config.Plugins.empty());
 		}

--- a/tests/catapult/config_holder/LocalNodeConfigurationHolderTests.cpp
+++ b/tests/catapult/config_holder/LocalNodeConfigurationHolderTests.cpp
@@ -45,6 +45,7 @@ namespace catapult { namespace config {
 			"\n"
 			"blockPruneInterval = 360\n"
 			"maxTransactionsPerBlock = 200'000\n\n"
+			"enableUnconfirmedTransactionMinFeeValidation = true\n\n"
 			"[plugin:catapult.plugins.config]\n"
 			"\n"
 			"maxBlockChainConfigSize = 1MB\n"

--- a/tests/catapult/model/NetworkConfigurationTests.cpp
+++ b/tests/catapult/model/NetworkConfigurationTests.cpp
@@ -68,7 +68,9 @@ namespace catapult { namespace model {
 							{ "harvestBeneficiaryPercentage", "56" },
 
 							{ "blockPruneInterval", "432" },
-							{ "maxTransactionsPerBlock", "120" }
+							{ "maxTransactionsPerBlock", "120" },
+
+							{ "enableUnconfirmedTransactionMinFeeValidation", "true" },
 						}
 					},
 					{
@@ -117,6 +119,8 @@ namespace catapult { namespace model {
 				EXPECT_EQ(0u, config.BlockPruneInterval);
 				EXPECT_EQ(0u, config.MaxTransactionsPerBlock);
 
+				EXPECT_EQ(false, config.EnableUnconfirmedTransactionMinFeeValidation);
+
 				EXPECT_TRUE(config.Plugins.empty());
 			}
 
@@ -145,6 +149,8 @@ namespace catapult { namespace model {
 
 				EXPECT_EQ(432u, config.BlockPruneInterval);
 				EXPECT_EQ(120u, config.MaxTransactionsPerBlock);
+
+				EXPECT_EQ(true, config.EnableUnconfirmedTransactionMinFeeValidation);
 
 				EXPECT_EQ(2u, config.Plugins.size());
 				const auto& pluginAlphaBag = config.Plugins.find("alpha")->second;

--- a/tests/test/local/LocalTestUtils.cpp
+++ b/tests/test/local/LocalTestUtils.cpp
@@ -254,6 +254,8 @@ namespace catapult { namespace test {
 		config.BlockPruneInterval = 360;
 		config.MaxTransactionsPerBlock = 200'000;
 
+		config.EnableUnconfirmedTransactionMinFeeValidation = true;
+
 		config.GreedDelta = 0.5;
 		config.GreedExponent = 2.0;
 		return config;

--- a/tests/test/other/MockExecutionConfiguration.h
+++ b/tests/test/other/MockExecutionConfiguration.h
@@ -245,12 +245,13 @@ namespace catapult { namespace test {
 
 	struct MockExecutionConfiguration {
 	public:
-		MockExecutionConfiguration()
+		MockExecutionConfiguration(BlockFeeMultiplier minFeeMultiplier = BlockFeeMultiplier())
 				: pObserver(std::make_shared<MockAggregateNotificationObserver>())
 				, pValidator(std::make_shared<MockAggregateNotificationValidator>())
 				, pNotificationPublisher(std::make_shared<MockNotificationPublisher>()) {
 			Config.NetworkIdentifier = Mock_Execution_Configuration_Network_Identifier;
 			Config.NetworkInfoSupplier = [](const Height&) { return model::NetworkInfo(); };
+			Config.MinFeeMultiplierSupplier = [minFeeMultiplier](const Height&) { return minFeeMultiplier; };
 			Config.pObserver = pObserver;
 			Config.pValidator = pValidator;
 			Config.pNotificationPublisher = pNotificationPublisher;


### PR DESCRIPTION
1. Made API nodes available for pulling unconfirmed transactions from them.
2. Made validation of unconfirmed transaction fee optional in order to enable propagation of unconfirmed transactions to the network even if a particular node is not interested in them because of their low fees. This way other nodes that would accept transactions with lower fee would be able to get them.
3. Made chainSyncedPredicate to return true for public network to avoid unconfirmed transaction synchronization issues in the case a malicious node lied about chain height.