### PR TITLE
Crash during syncing with old node

### DIFF
--- a/src/catapult/model/NetworkConfiguration.h
+++ b/src/catapult/model/NetworkConfiguration.h
@@ -113,8 +113,10 @@ namespace catapult { namespace model {
 		template<typename T>
 		T LoadPluginConfiguration() const {
 			auto iter = Plugins.find(T::Name);
-			if (Plugins.cend() == iter)
-				CATAPULT_THROW_AND_LOG_1(catapult_invalid_argument, "can't load plugin", std::string(T::Name));
+			if (Plugins.cend() == iter) {
+				CATAPULT_LOG(info) << "can't load plugin " << T::Name;
+				return T::Uninitialized();
+			}
 
 			return T::LoadFromBag(iter->second);
 		}

--- a/tests/catapult/model/NetworkConfigurationTests.cpp
+++ b/tests/catapult/model/NetworkConfigurationTests.cpp
@@ -281,6 +281,10 @@ namespace catapult { namespace model {
 				utils::VerifyBagSizeLte(bag, 2);
 				return config;
 			}
+
+			static BetaConfiguration Uninitialized() {
+				return BetaConfiguration();
+			}
 		};
 
 		struct GammaConfiguration {
@@ -294,6 +298,10 @@ namespace catapult { namespace model {
 				utils::LoadIniProperty(bag, "", "Foo", config.Foo);
 				utils::VerifyBagSizeLte(bag, 1);
 				return config;
+			}
+
+			static GammaConfiguration Uninitialized() {
+				return GammaConfiguration();
 			}
 		};
 	}
@@ -311,13 +319,15 @@ namespace catapult { namespace model {
 		EXPECT_EQ("zeta", betaConfig.Baz);
 	}
 
-	TEST(TEST_CLASS, LoadPluginConfigurationFailsWhenPluginConfigurationIsNotPresent) {
+	TEST(TEST_CLASS, LoadPluginConfigurationDefaultWhenPluginConfigurationIsNotPresent) {
 		// Arrange:
 		using Traits = NetworkConfigurationTraits;
 		auto config = Traits::ConfigurationType::LoadFromBag(Traits::CreateProperties());
 
 		// Act + Assert:
-		EXPECT_THROW(LoadPluginConfiguration<GammaConfiguration>(config), catapult_invalid_argument);
+		auto loadedConfig = LoadPluginConfiguration<GammaConfiguration>(config);
+		auto expectedConfig = GammaConfiguration::Uninitialized();
+		EXPECT_EQ(expectedConfig.Foo, loadedConfig.Foo);
 	}
 
 	// endregion


### PR DESCRIPTION
Instead of throwing error when network config doesn't contain plugin, let's return default config.