### PR TITLE
Revert "Swaped Owner and Drive in Prepare drive transaction. Now Signer must be owner instead of Drive."

### DIFF
--- a/extensions/mongo/plugins/service/src/PrepareDriveMapper.cpp
+++ b/extensions/mongo/plugins/service/src/PrepareDriveMapper.cpp
@@ -15,7 +15,7 @@ namespace catapult { namespace mongo { namespace plugins {
 
 	template<typename TTransaction>
 	void StreamPrepareDriveTransaction(bson_stream::document& builder, const TTransaction& transaction) {
-		builder << "drive" << ToBinary(transaction.DriveKey);
+		builder << "owner" << ToBinary(transaction.Owner);
 		builder << "duration" << ToInt64(transaction.Duration);
 		builder << "billingPeriod" << ToInt64(transaction.BillingPeriod);
 		builder << "billingPrice" << ToInt64(transaction.BillingPrice);

--- a/extensions/mongo/plugins/service/tests/PrepareDriveMapperTests.cpp
+++ b/extensions/mongo/plugins/service/tests/PrepareDriveMapperTests.cpp
@@ -20,7 +20,7 @@ namespace catapult { namespace mongo { namespace plugins {
 
 		template<typename TTransaction>
 		void AssertEqualNonInheritedData(const TTransaction& transaction, const bsoncxx::document::view& dbTransaction) {
-			EXPECT_EQ(transaction.DriveKey, test::GetKeyValue(dbTransaction, "drive"));
+			EXPECT_EQ(transaction.Owner, test::GetKeyValue(dbTransaction, "owner"));
 			EXPECT_EQ(transaction.Duration.unwrap(), test::GetUint64(dbTransaction, "duration"));
 			EXPECT_EQ(transaction.BillingPeriod.unwrap(), test::GetUint64(dbTransaction, "billingPeriod"));
 			EXPECT_EQ(transaction.BillingPrice.unwrap(), test::GetUint64(dbTransaction, "billingPrice"));

--- a/plugins/txes/service/src/model/PrepareDriveTransaction.h
+++ b/plugins/txes/service/src/model/PrepareDriveTransaction.h
@@ -23,8 +23,8 @@ namespace catapult { namespace model {
 		DEFINE_TRANSACTION_CONSTANTS(Entity_Type_PrepareDrive, 1)
 
 	public:
-		/// Key of drive.
-		Key DriveKey;
+		/// Owner of drive.
+		Key Owner;
 
 		/// Duration of drive.
 		BlockDuration Duration;
@@ -60,6 +60,6 @@ namespace catapult { namespace model {
 
 	/// Extracts public keys of additional accounts that must approve \a transaction.
 	inline utils::KeySet ExtractAdditionalRequiredCosigners(const EmbeddedPrepareDriveTransaction& transaction) {
-		return { transaction.DriveKey };
+		return { transaction.Owner };
 	}
 }}

--- a/plugins/txes/service/src/plugins/PrepareDriveTransactionPlugin.cpp
+++ b/plugins/txes/service/src/plugins/PrepareDriveTransactionPlugin.cpp
@@ -20,8 +20,8 @@ namespace catapult { namespace plugins {
 			switch (transaction.EntityVersion()) {
 			case 1: {
 				sub.notify(PrepareDriveNotification<1>(
-					transaction.DriveKey,
 					transaction.Signer,
+					transaction.Owner,
 					transaction.Duration,
 					transaction.BillingPeriod,
 					transaction.BillingPrice,

--- a/plugins/txes/service/tests/plugins/PrepareDriveTransactionPluginTests.cpp
+++ b/plugins/txes/service/tests/plugins/PrepareDriveTransactionPluginTests.cpp
@@ -90,8 +90,8 @@ namespace catapult { namespace plugins {
 		// Assert:
 		ASSERT_EQ(1u, sub.numMatchingNotifications());
 		const auto& notification = sub.matchingNotifications()[0];
-		EXPECT_EQ(pTransaction->Signer, notification.Owner);
-		EXPECT_EQ(pTransaction->DriveKey, notification.DriveKey);
+		EXPECT_EQ(pTransaction->Signer, notification.DriveKey);
+		EXPECT_EQ(pTransaction->Owner, notification.Owner);
 		EXPECT_EQ(pTransaction->Duration, notification.Duration);
 		EXPECT_EQ(pTransaction->BillingPeriod, notification.BillingPeriod);
 		EXPECT_EQ(pTransaction->BillingPrice, notification.BillingPrice);

--- a/plugins/txes/service/tests/test/ServiceTestUtils.h
+++ b/plugins/txes/service/tests/test/ServiceTestUtils.h
@@ -190,7 +190,7 @@ namespace catapult { namespace test {
     template<typename TTransaction>
 	model::UniqueEntityPtr<TTransaction> CreatePrepareDriveTransaction() {
 		auto pTransaction = CreateDriveTransaction<TTransaction>(model::Entity_Type_PrepareDrive);
-		pTransaction->DriveKey = test::GenerateRandomByteArray<Key>();
+		pTransaction->Owner = test::GenerateRandomByteArray<Key>();
 		pTransaction->Duration = BlockDuration(1000);
 		pTransaction->BillingPeriod = BlockDuration(100);
 		pTransaction->BillingPrice = Amount(100);


### PR DESCRIPTION
This reverts commit 2a92861
We decided revert this change to be compatible with multisig flow