### PR TITLE
Initial implementation

### DIFF
--- a/extensions/mongo/plugins/mosaic/src/MosaicDefinitionMapper.cpp
+++ b/extensions/mongo/plugins/mosaic/src/MosaicDefinitionMapper.cpp
@@ -22,6 +22,7 @@
 #include "mongo/src/MongoTransactionPluginFactory.h"
 #include "mongo/src/mappers/MapperUtils.h"
 #include "plugins/txes/mosaic/src/model/MosaicDefinitionTransaction.h"
+#include "plugins/txes/mosaic/src/model/MosaicLevy.h"
 
 using namespace catapult::mongo::mappers;
 
@@ -46,6 +47,17 @@ namespace catapult { namespace mongo { namespace plugins {
 				StreamProperty(context, pProperty->Id, pProperty->Value);
 		}
 
+		void StreamLevyProperties(bson_stream::array_context& context, const model::MosaicLevy& levy)
+		{
+			context
+					<< bson_stream::open_document
+				//	<< "levyType" << utils::to_underlying_type(levy.Type)
+					<< "recipient" << ToBinary(levy.Recipient)
+					<< "mosaicId" << ToInt64(levy.MosaicId)
+					<< "fee" << ToInt64(levy.Fee)
+					<< bson_stream::close_document;
+		}
+
 		template<typename TTransaction>
 		void StreamTransaction(bson_stream::document& builder, const TTransaction& transaction) {
 			builder
@@ -55,6 +67,11 @@ namespace catapult { namespace mongo { namespace plugins {
 			StreamRequiredProperties(propertiesArray, transaction.PropertiesHeader);
 			StreamOptionalProperties(propertiesArray, transaction.PropertiesPtr(), transaction.PropertiesHeader.Count);
 			propertiesArray << bson_stream::close_array;
+
+			auto levy = builder << "levy" << bson_stream::open_array;
+			StreamLevyProperties(levy, transaction.Levy);
+			levy << bson_stream::close_array;
+
 		}
 	}
 

--- a/extensions/mongo/plugins/mosaic/tests/mappers/MosaicEntryMapperTests.cpp
+++ b/extensions/mongo/plugins/mosaic/tests/mappers/MosaicEntryMapperTests.cpp
@@ -35,7 +35,7 @@ namespace catapult { namespace mongo { namespace plugins {
 	namespace {
 		state::MosaicEntry CreateMosaicEntry() {
 			auto owner = test::GenerateRandomByteArray<Key>();
-			return test::CreateMosaicEntry(MosaicId(345), Height(123), owner, Amount(456), BlockDuration(12345));
+			return test::CreateMosaicEntry(MosaicId(345), Height(123), owner, Amount(456), BlockDuration(12345)); //todo: need change
 		}
 
 		void AssertEqualMosaicEntryMetadata(const bsoncxx::document::view& dbMetadata) {

--- a/plugins/txes/metadata/tests/validators/ModifyMosaicMetadataValidatorTests.cpp
+++ b/plugins/txes/metadata/tests/validators/ModifyMosaicMetadataValidatorTests.cpp
@@ -25,7 +25,7 @@ namespace catapult { namespace validators {
 			auto& mosaicCacheDelta = delta.sub<cache::MosaicCache>();
 			
 			model::MosaicProperties::PropertyValuesContainer values{};
-			auto definition = state::MosaicDefinition(Height(1), Mosaic_Owner, 3, model::MosaicProperties::FromValues(values));
+			auto definition = state::MosaicDefinition(Height(1), Mosaic_Owner, 3, model::MosaicProperties::FromValues(values), model::MosaicLevy());
 			auto entry = state::MosaicEntry(Mosaic_Id, definition);
 			entry.increaseSupply(Amount(666));
 			mosaicCacheDelta.insert(entry);

--- a/plugins/txes/mosaic/src/model/MosaicDefinitionTransaction.h
+++ b/plugins/txes/mosaic/src/model/MosaicDefinitionTransaction.h
@@ -22,6 +22,7 @@
 #include "MosaicConstants.h"
 #include "MosaicEntityType.h"
 #include "MosaicProperties.h"
+#include "MosaicLevy.h"
 #include "catapult/model/Transaction.h"
 
 namespace catapult { namespace model {
@@ -45,6 +46,9 @@ namespace catapult { namespace model {
 		/// \note This must match the generated id.
 		catapult::MosaicId MosaicId;
 
+		/// Levy
+		MosaicLevy Levy;
+
 		/// Properties header.
 		MosaicPropertiesHeader PropertiesHeader;
 
@@ -60,7 +64,7 @@ namespace catapult { namespace model {
 	public:
 		/// Calculates the real size of mosaic definition \a transaction.
 		static constexpr uint64_t CalculateRealSize(const TransactionType& transaction) noexcept {
-			return sizeof(TransactionType) + transaction.PropertiesHeader.Count * sizeof(MosaicProperty);
+			return sizeof(TransactionType) + transaction.PropertiesHeader.Count * sizeof(MosaicProperty) ;
 		}
 	};
 

--- a/plugins/txes/mosaic/src/model/MosaicLevy.h
+++ b/plugins/txes/mosaic/src/model/MosaicLevy.h
@@ -1,0 +1,41 @@
+#pragma once
+
+namespace catapult { namespace model {
+	/// Available mosaic levy rule ids.
+	enum class LevyType : uint16_t {
+		/// Default there is no levy
+		None = 0x1,
+
+		/// Constant value
+		Absolute,
+
+		/// Use percentile fee.
+		Percentile,
+	};
+
+#pragma pack(push, 1)
+	struct MosaicLevy {
+		/// Levy type
+		LevyType Type;
+
+		/// Transaction recipient.
+		UnresolvedAddress Recipient;
+
+		// Levy mosaic currency
+		catapult::MosaicId MosaicId;
+
+		/// the set Levy fee
+		catapult::Amount Fee;
+
+		/// default constructor
+		MosaicLevy() = default;
+
+		/// constructor with params
+		MosaicLevy(LevyType type, UnresolvedAddress recipient, catapult::MosaicId mosaicId, catapult::Amount fee)
+			: Type(type)
+			, Recipient(recipient)
+			, MosaicId(mosaicId)
+			, Fee(fee) {}
+	};
+#pragma pack(pop)
+}}

--- a/plugins/txes/mosaic/src/model/MosaicNotifications.h
+++ b/plugins/txes/mosaic/src/model/MosaicNotifications.h
@@ -22,6 +22,7 @@
 #include "MosaicConstants.h"
 #include "MosaicProperties.h"
 #include "MosaicTypes.h"
+#include "MosaicLevy.h"
 #include "catapult/model/Notifications.h"
 
 namespace catapult { namespace model {
@@ -91,11 +92,13 @@ namespace catapult { namespace model {
 
 	public:
 		/// Creates a notification around \a signer, \a mosaicId and \a properties.
-		explicit MosaicDefinitionNotification(const Key& signer, MosaicId mosaicId, const MosaicProperties& properties)
+		explicit MosaicDefinitionNotification(const Key& signer, MosaicId mosaicId,
+				const MosaicProperties& properties, const MosaicLevy& levy)
 				: Notification(Notification_Type, sizeof(MosaicDefinitionNotification<1>))
 				, Signer(signer)
 				, MosaicId(mosaicId)
 				, Properties(properties)
+				, Levy(levy)
 		{}
 
 	public:
@@ -107,6 +110,9 @@ namespace catapult { namespace model {
 
 		/// Mosaic properties.
 		MosaicProperties Properties;
+
+		/// Mosaic Levy
+		MosaicLevy Levy;
 	};
 
 	/// Notification of a mosaic nonce and id.

--- a/plugins/txes/mosaic/src/observers/MosaicDefinitionObserver.cpp
+++ b/plugins/txes/mosaic/src/observers/MosaicDefinitionObserver.cpp
@@ -52,7 +52,7 @@ namespace catapult { namespace observers {
 			const auto& currentDefinition = currentEntry.definition();
 			auto newProperties = MergeProperties(currentDefinition.properties(), notification.Properties, mode);
 			auto revision = NotifyMode::Commit == mode ? currentDefinition.revision() + 1 : currentDefinition.revision() - 1;
-			auto definition = state::MosaicDefinition(currentDefinition.height(), notification.Signer, revision, newProperties);
+			auto definition = state::MosaicDefinition(currentDefinition.height(), notification.Signer, revision, newProperties, notification.Levy);
 			return state::MosaicEntry(notification.MosaicId, definition);
 		}
 	}
@@ -72,7 +72,7 @@ namespace catapult { namespace observers {
 
 			cache.insert(ApplyNotification(mosaicEntry, notification, context.Mode));
 		} else {
-			auto definition = state::MosaicDefinition(context.Height, notification.Signer, 1, notification.Properties);
+			auto definition = state::MosaicDefinition(context.Height, notification.Signer, 1, notification.Properties, notification.Levy);
 			cache.insert(state::MosaicEntry(notification.MosaicId, definition));
 		}
 	});

--- a/plugins/txes/mosaic/src/plugins/MosaicDefinitionTransactionPlugin.cpp
+++ b/plugins/txes/mosaic/src/plugins/MosaicDefinitionTransactionPlugin.cpp
@@ -77,7 +77,8 @@ namespace catapult { namespace plugins {
 					sub.notify(MosaicDefinitionNotification<1>(
 						transaction.Signer,
 						transaction.MosaicId,
-						ExtractAllProperties(transaction.PropertiesHeader, transaction.PropertiesPtr())));
+						ExtractAllProperties(transaction.PropertiesHeader, transaction.PropertiesPtr()),
+						transaction.Levy));
 					break;
 
 				default:

--- a/plugins/txes/mosaic/src/state/MosaicDefinition.h
+++ b/plugins/txes/mosaic/src/state/MosaicDefinition.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "src/model/MosaicProperties.h"
+#include "src/model/MosaicLevy.h"
 #include "catapult/types.h"
 
 namespace catapult { namespace state {
@@ -28,11 +29,13 @@ namespace catapult { namespace state {
 	class MosaicDefinition {
 	public:
 		/// Creates a mosaic definition around \a height, \a owner, mosaic \a revision and mosaic \a properties.
-		explicit MosaicDefinition(Height height, const Key& owner, uint32_t revision, const model::MosaicProperties& properties)
+		explicit MosaicDefinition(Height height, const Key& owner, uint32_t revision,
+				const model::MosaicProperties& properties, const model::MosaicLevy& levy)
 				: m_height(height)
 				, m_owner(owner)
 				, m_revision(revision)
 				, m_properties(properties)
+				, m_levy(levy)
 		{}
 
 	public:
@@ -65,10 +68,15 @@ namespace catapult { namespace state {
 			return m_properties;
 		}
 
+		const model::MosaicLevy& levy() const {
+			return m_levy;
+		}
+
 	private:
 		Height m_height;
 		Key m_owner;
 		uint32_t m_revision;
 		model::MosaicProperties m_properties;
+		model::MosaicLevy m_levy;
 	};
 }}

--- a/plugins/txes/mosaic/tests/cache/MosaicCacheStorageTests.cpp
+++ b/plugins/txes/mosaic/tests/cache/MosaicCacheStorageTests.cpp
@@ -41,7 +41,7 @@ namespace catapult { namespace cache {
 
 			static auto CreateValue(MosaicId id) {
 				auto properties = test::CreateMosaicPropertiesWithDuration(BlockDuration(37));
-				auto definition = state::MosaicDefinition(Height(11), test::GenerateRandomByteArray<Key>(), 3, properties);
+				auto definition = state::MosaicDefinition(Height(11), test::GenerateRandomByteArray<Key>(), 3, properties, model::MosaicLevy()); //todo: need change
 				return state::MosaicEntry(id, definition);
 			}
 

--- a/plugins/txes/mosaic/tests/cache/MosaicCacheTests.cpp
+++ b/plugins/txes/mosaic/tests/cache/MosaicCacheTests.cpp
@@ -57,14 +57,14 @@ namespace catapult { namespace cache {
 
 			static ValueType CreateWithId(uint8_t id) {
 				auto key = Key{ { static_cast<uint8_t>(id * 2) }};
-				auto definition = state::MosaicDefinition(Height(), key, 3, model::MosaicProperties::FromValues({}));
+				auto definition = state::MosaicDefinition(Height(), key, 3, model::MosaicProperties::FromValues({}), model::MosaicLevy());
 				return state::MosaicEntry(MakeId(id), definition);
 			}
 
 			static ValueType CreateWithIdAndExpiration(uint8_t id, Height height) {
 				// simulate behavior of lock info cache activation (so expiration is at specified height)
 				auto properties = model::MosaicProperties::FromValues({ { 0, 0, height.unwrap() - 1 } });
-				auto definition = state::MosaicDefinition(Height(1), Key(), 3, properties);
+				auto definition = state::MosaicDefinition(Height(1), Key(), 3, properties, model::MosaicLevy());
 				return state::MosaicEntry(MakeId(id), definition);
 			}
 		};

--- a/plugins/txes/mosaic/tests/model/MosaicDefinitionTransactionTests.cpp
+++ b/plugins/txes/mosaic/tests/model/MosaicDefinitionTransactionTests.cpp
@@ -43,11 +43,12 @@ namespace catapult { namespace model {
 					baseSize // base
 					+ sizeof(uint32_t) // nonce
 					+ sizeof(MosaicId) // id
-					+ expectedPropertiesHeaderSize;
+					+ expectedPropertiesHeaderSize
+					+ sizeof(MosaicLevy);
 
 			// Assert:
 			EXPECT_EQ(expectedSize, sizeof(T));
-			EXPECT_EQ(baseSize + 15u, sizeof(T));
+			EXPECT_EQ(baseSize + 15u + sizeof(MosaicLevy), sizeof(T));
 		}
 
 		template<typename T>
@@ -67,7 +68,7 @@ namespace catapult { namespace model {
 	namespace {
 		struct MosaicDefinitionTransactionTraits {
 			static auto GenerateEntityWithAttachments(uint8_t propertiesCount) {
-				uint32_t entitySize = sizeof(MosaicDefinitionTransaction) + propertiesCount * sizeof(MosaicProperty);
+				uint32_t entitySize = sizeof(MosaicDefinitionTransaction) + propertiesCount * sizeof(MosaicProperty) + sizeof(MosaicLevy);
 				auto pTransaction = utils::MakeUniqueWithSize<MosaicDefinitionTransaction>(entitySize);
 				pTransaction->Size = entitySize;
 				pTransaction->PropertiesHeader.Count = propertiesCount;

--- a/plugins/txes/mosaic/tests/observers/MosaicDefinitionObserverTests.cpp
+++ b/plugins/txes/mosaic/tests/observers/MosaicDefinitionObserverTests.cpp
@@ -39,7 +39,7 @@ namespace catapult { namespace observers {
 
 		model::MosaicDefinitionNotification<1> CreateDefaultNotification(const Key& signer) {
 			auto properties = model::MosaicProperties::FromValues({ { 3, 6, 15 } });
-			return model::MosaicDefinitionNotification<1>(signer, Default_Mosaic_Id, properties);
+			return model::MosaicDefinitionNotification<1>(signer, Default_Mosaic_Id, properties, model::MosaicLevy());
 		}
 
 		template<typename TSeedCacheFunc, typename TCheckCacheFunc>
@@ -67,7 +67,7 @@ namespace catapult { namespace observers {
 		}
 
 		void SeedCacheWithDefaultMosaic(cache::MosaicCacheDelta& mosaicCacheDelta) {
-			auto definition = state::MosaicDefinition(Seed_Height, Key(), 1, model::MosaicProperties::FromValues({ { 1, 2, 20 } }));
+			auto definition = state::MosaicDefinition(Seed_Height, Key(), 1, model::MosaicProperties::FromValues({ { 1, 2, 20 } }), model::MosaicLevy());
 			mosaicCacheDelta.insert(state::MosaicEntry(Default_Mosaic_Id, definition));
 
 			// Sanity:
@@ -139,7 +139,7 @@ namespace catapult { namespace observers {
 	namespace {
 		void AddTwoMosaics(cache::MosaicCacheDelta& mosaicCacheDelta, uint32_t revision) {
 			auto properties = model::MosaicProperties::FromValues({ { 2, 4, 20 + 15 } });
-			auto definition = state::MosaicDefinition(Seed_Height, Key(), revision, properties);
+			auto definition = state::MosaicDefinition(Seed_Height, Key(), revision, properties, model::MosaicLevy());
 			for (auto id : { Default_Mosaic_Id, MosaicId(987) })
 				mosaicCacheDelta.insert(state::MosaicEntry(id, definition));
 

--- a/plugins/txes/mosaic/tests/plugins/MosaicDefinitionTransactionPluginTests.cpp
+++ b/plugins/txes/mosaic/tests/plugins/MosaicDefinitionTransactionPluginTests.cpp
@@ -88,7 +88,7 @@ namespace catapult { namespace plugins {
 		auto realSize = pPlugin->calculateRealSize(transaction);
 
 		// Assert:
-		EXPECT_EQ(sizeof(typename TTraits::TransactionType) + 2 * sizeof(MosaicProperty), realSize);
+		EXPECT_EQ(sizeof(typename TTraits::TransactionType) + 2 * sizeof(MosaicProperty) + sizeof(MosaicLevy), realSize);
 	}
 
 	PLUGIN_TEST(CanExtractAccounts) {
@@ -172,7 +172,7 @@ namespace catapult { namespace plugins {
 		template<typename TTraits>
 		auto CreateTransactionWithProperties(uint8_t numProperties) {
 			using TransactionType = typename TTraits::TransactionType;
-			uint32_t entitySize = sizeof(TransactionType) + numProperties * sizeof(MosaicProperty);
+			uint32_t entitySize = sizeof(TransactionType) + sizeof(MosaicLevy) + numProperties * sizeof(MosaicProperty);
 			auto pTransaction = utils::MakeUniqueWithSize<TransactionType>(entitySize);
 			pTransaction->Version = Transaction_Version;
 			pTransaction->Size = entitySize;

--- a/plugins/txes/mosaic/tests/state/MosaicDefinitionTests.cpp
+++ b/plugins/txes/mosaic/tests/state/MosaicDefinitionTests.cpp
@@ -43,7 +43,7 @@ namespace catapult { namespace state {
 
 		MosaicDefinition CreateMosaicDefinition(uint64_t duration) {
 			auto owner = test::GenerateRandomByteArray<Key>();
-			return MosaicDefinition(Default_Height, owner, 3, test::CreateMosaicPropertiesWithDuration(BlockDuration(duration)));
+			return MosaicDefinition(Default_Height, owner, 3, test::CreateMosaicPropertiesWithDuration(BlockDuration(duration)), model::MosaicLevy());
 		}
 	}
 
@@ -55,7 +55,7 @@ namespace catapult { namespace state {
 		auto properties = model::MosaicProperties::FromValues({});
 
 		// Act:
-		MosaicDefinition definition(Height(877), owner, 3, properties);
+		MosaicDefinition definition(Height(877), owner, 3, properties, model::MosaicLevy());
 
 		// Assert:
 		EXPECT_EQ(Height(877), definition.height());
@@ -71,7 +71,7 @@ namespace catapult { namespace state {
 		auto properties = test::CreateMosaicPropertiesWithDuration(BlockDuration(3));
 
 		// Act:
-		MosaicDefinition definition(Height(877), owner, 3, properties);
+		MosaicDefinition definition(Height(877), owner, 3, properties, model::MosaicLevy());  //todo need change
 
 		// Assert:
 		EXPECT_EQ(Height(877), definition.height());

--- a/plugins/txes/mosaic/tests/state/MosaicEntryTests.cpp
+++ b/plugins/txes/mosaic/tests/state/MosaicEntryTests.cpp
@@ -101,7 +101,7 @@ namespace catapult { namespace state {
 	namespace {
 		MosaicDefinition CreateMosaicDefinition(Height height, uint64_t duration) {
 			auto owner = test::GenerateRandomByteArray<Key>();
-			return MosaicDefinition(height, owner, 3, test::CreateMosaicPropertiesWithDuration(BlockDuration(duration)));
+			return MosaicDefinition(height, owner, 3, test::CreateMosaicPropertiesWithDuration(BlockDuration(duration)), model::MosaicLevy());
 		}
 	}
 

--- a/plugins/txes/mosaic/tests/test/MosaicCacheTestUtils.cpp
+++ b/plugins/txes/mosaic/tests/test/MosaicCacheTestUtils.cpp
@@ -27,7 +27,7 @@ namespace catapult { namespace test {
 
 	void AddMosaic(cache::CatapultCacheDelta& cache, MosaicId id, Height height, BlockDuration duration, Amount supply) {
 		auto& mosaicCacheDelta = cache.sub<cache::MosaicCache>();
-		auto definition = state::MosaicDefinition(height, Key(), 1, test::CreateMosaicPropertiesWithDuration(duration));
+		auto definition = state::MosaicDefinition(height, Key(), 1, test::CreateMosaicPropertiesWithDuration(duration), model::MosaicLevy());
 		auto entry = state::MosaicEntry(id, definition);
 		entry.increaseSupply(supply);
 		mosaicCacheDelta.insert(entry);
@@ -35,7 +35,7 @@ namespace catapult { namespace test {
 
 	void AddMosaic(cache::CatapultCacheDelta& cache, MosaicId id, Height height, BlockDuration duration, const Key& owner) {
 		auto& mosaicCacheDelta = cache.sub<cache::MosaicCache>();
-		auto definition = state::MosaicDefinition(height, owner, 1, test::CreateMosaicPropertiesWithDuration(duration));
+		auto definition = state::MosaicDefinition(height, owner, 1, test::CreateMosaicPropertiesWithDuration(duration), model::MosaicLevy());
 		mosaicCacheDelta.insert(state::MosaicEntry(id, definition));
 	}
 
@@ -45,7 +45,7 @@ namespace catapult { namespace test {
 
 	void AddEternalMosaic(cache::CatapultCacheDelta& cache, MosaicId id, Height height, const Key& owner) {
 		auto& mosaicCacheDelta = cache.sub<cache::MosaicCache>();
-		auto definition = state::MosaicDefinition(height, owner, 1, model::MosaicProperties::FromValues({}));
+		auto definition = state::MosaicDefinition(height, owner, 1, model::MosaicProperties::FromValues({}), model::MosaicLevy());
 		mosaicCacheDelta.insert(state::MosaicEntry(id, definition));
 	}
 

--- a/plugins/txes/mosaic/tests/test/MosaicTestUtils.cpp
+++ b/plugins/txes/mosaic/tests/test/MosaicTestUtils.cpp
@@ -30,7 +30,7 @@ namespace catapult { namespace test {
 	}
 
 	state::MosaicDefinition CreateMosaicDefinition(Height height) {
-		return state::MosaicDefinition(height, test::GenerateRandomByteArray<Key>(), 3, model::MosaicProperties::FromValues({}));
+		return state::MosaicDefinition(height, test::GenerateRandomByteArray<Key>(), 3, model::MosaicProperties::FromValues({}), model::MosaicLevy());
 	}
 
 	state::MosaicEntry CreateMosaicEntry(MosaicId id, Amount supply) {
@@ -45,7 +45,7 @@ namespace catapult { namespace test {
 
 	namespace {
 		state::MosaicDefinition CreateMosaicDefinition(Height height, const Key& owner, BlockDuration duration) {
-			return state::MosaicDefinition(height, owner, 3, CreateMosaicPropertiesWithDuration(duration));
+			return state::MosaicDefinition(height, owner, 3, CreateMosaicPropertiesWithDuration(duration), model::MosaicLevy());
 		}
 	}
 

--- a/plugins/txes/mosaic/tests/validators/MosaicAvailabilityValidatorTests.cpp
+++ b/plugins/txes/mosaic/tests/validators/MosaicAvailabilityValidatorTests.cpp
@@ -39,7 +39,7 @@ namespace catapult { namespace validators {
 				uint8_t divisibility,
 				BlockDuration duration) {
 			auto properties = model::MosaicProperties::FromValues({ { 0, divisibility, duration.unwrap() } });
-			return model::MosaicDefinitionNotification<1>(signer, id, properties);
+			return model::MosaicDefinitionNotification<1>(signer, id, properties, model::MosaicLevy());
 		}
 
 		model::MosaicDefinitionNotification<1> CreateNotification(const Key& signer, MosaicId id, BlockDuration duration) {

--- a/plugins/txes/mosaic/tests/validators/MosaicDurationValidatorTests.cpp
+++ b/plugins/txes/mosaic/tests/validators/MosaicDurationValidatorTests.cpp
@@ -38,7 +38,7 @@ namespace catapult { namespace validators {
 
 		model::MosaicDefinitionNotification<1> CreateNotification(const Key& signer, BlockDuration duration) {
 			auto properties = model::MosaicProperties::FromValues({ { 1, 2, duration.unwrap() } });
-			return model::MosaicDefinitionNotification<1>(signer, Default_Mosaic_Id, properties);
+			return model::MosaicDefinitionNotification<1>(signer, Default_Mosaic_Id, properties, model::MosaicLevy());
 		}
 
 		void AddMosaic(cache::CatapultCache& cache, const Key& owner, BlockDuration duration) {

--- a/plugins/txes/mosaic/tests/validators/MosaicSupplyChangeAllowedValidatorTests.cpp
+++ b/plugins/txes/mosaic/tests/validators/MosaicSupplyChangeAllowedValidatorTests.cpp
@@ -67,7 +67,7 @@ namespace catapult { namespace validators {
 			values[utils::to_underlying_type(model::MosaicPropertyId::Flags)] = utils::to_underlying_type(flags);
 
 			auto& mosaicCacheDelta = delta.sub<cache::MosaicCache>();
-			auto definition = state::MosaicDefinition(Height(50), Key(), 3, model::MosaicProperties::FromValues(values));
+			auto definition = state::MosaicDefinition(Height(50), Key(), 3, model::MosaicProperties::FromValues(values), model::MosaicLevy());
 			auto entry = state::MosaicEntry(id, definition);
 			entry.increaseSupply(mosaicSupply);
 			mosaicCacheDelta.insert(entry);

--- a/plugins/txes/mosaic/tests/validators/MosaicTransferValidatorTests.cpp
+++ b/plugins/txes/mosaic/tests/validators/MosaicTransferValidatorTests.cpp
@@ -45,7 +45,7 @@ namespace catapult { namespace validators {
 		}
 
 		state::MosaicDefinition CreateMosaicDefinition(Height height, const Key& owner, model::MosaicFlags flags) {
-			return state::MosaicDefinition(height, owner, 3, CreateMosaicProperties(flags));
+			return state::MosaicDefinition(height, owner, 3, CreateMosaicProperties(flags), model::MosaicLevy());
 		}
 
 		state::MosaicEntry CreateMosaicEntry(MosaicId mosaicId, const Key& owner, model::MosaicFlags flags) {

--- a/tools/nemgen/NemesisConfiguration.cpp
+++ b/tools/nemgen/NemesisConfiguration.cpp
@@ -101,7 +101,7 @@ namespace catapult { namespace tools { namespace nemgen {
 				flags |= model::MosaicFlags::Supply_Mutable;
 
 			values[utils::to_underlying_type(model::MosaicPropertyId::Flags)] = utils::to_underlying_type(flags);
-			state::MosaicDefinition definition(Height(1), owner, 1, model::MosaicProperties::FromValues(values));
+			state::MosaicDefinition definition(Height(1), owner, 1, model::MosaicProperties::FromValues(values), model::MosaicLevy());
 			return ToMosaicEntry(definition, mosaicNonce, supply);
 		}
 


### PR DESCRIPTION
Draft PR:

Added Levy information to MosaicDefinitionTransaction
added levy info to mongo extensions
Unit tests are updated to include Levy, but needs updates to include levy info testing.  More unit test are needed to check levy info (store and retrieve cache, data integrity check from SDK pass, etc).

Note: this is incomplete yet (no levy functionality), I thought it is better to review earlier before implementation get big.