### PR TITLE
Bigfix/mosaic expire

### DIFF
--- a/plugins/txes/mosaic/src/plugins/MosaicPlugin.cpp
+++ b/plugins/txes/mosaic/src/plugins/MosaicPlugin.cpp
@@ -154,18 +154,17 @@ namespace catapult { namespace plugins {
 			auto resolverContext = manager.createResolverContext(cache);
 			auto mosaicId = resolverContext.resolve(unresolvedMosaicId);
 			
+			// If there are no levy, resolved to base mosaic
+			resolved = mosaicId;
+			
 			auto mosaicIter = levyCache.find(mosaicId);
-			if (!mosaicIter.tryGet())
-				return false;
-			
-			auto& entry = mosaicIter.get();
-			auto pLevy = entry.levy();
-			
-			if(pLevy == nullptr)
-				return false;
-			
-			resolved = pLevy->MosaicId;
-			return true;
+			if (mosaicIter.tryGet()) {
+				auto& entry = mosaicIter.get();
+				auto pLevy = entry.levy();
+				
+				if(pLevy != nullptr)
+					resolved = pLevy->MosaicId;
+			}
 		});
 		
 		manager.addAmountResolver([&manager](const auto& cache, const auto& unresolved, auto& resolved) {


### PR DESCRIPTION
In MosaicTransfer Validator, when a mosaic with no levy is resolved, it does not resolve properly since the resolver will return false and it will just use the default resolver which is just unwrapping the number.

case:
XPX: 13833723942089965046 
unresolved mosaic id 13833723942089965046 resolved to 992621222383397347
however there is no mosaic levy, therefore it returns false and just resolve to 13833723942089965046

the correct one is it should resolve to  992621222383397347 or base mosaic.