### PR TITLE
Resolve namespace id during address extraction (task#6anmjk)

### DIFF
--- a/extensions/addressextraction/AddressExtractionExtension.cpp
+++ b/extensions/addressextraction/AddressExtractionExtension.cpp
@@ -35,10 +35,14 @@ namespace catapult { namespace addressextraction {
 				[&bootstrapper]() {
 					return bootstrapper.pluginManager().createExtractorContext(bootstrapper.cacheHolder().cache());
 				},
-				[&bootstrapper](UnresolvedAddress address) {
-					auto cache = bootstrapper.cacheHolder().cache().createView().toReadOnly();
-					auto resolver =  bootstrapper.pluginManager().createResolverContext(cache);
-					return resolver.resolve(address);
+				[&bootstrapper]() {
+					return util::ResolverContextHandle(
+						[&bootstrapper](){
+							return bootstrapper.cacheHolder().cache().createView().toReadOnly();
+						},
+						[&bootstrapper](auto& cache){
+							return bootstrapper.pluginManager().createResolverContext(cache);
+						});
 				});
 
 			// add a dummy service for extending service lifetimes

--- a/extensions/addressextraction/src/AddressExtractor.cpp
+++ b/extensions/addressextraction/src/AddressExtractor.cpp
@@ -20,15 +20,14 @@
 
 #include "AddressExtractor.h"
 #include "catapult/model/Elements.h"
-#include "catapult/model/TransactionUtils.h"
 
 namespace catapult { namespace addressextraction {
 
 	AddressExtractor::AddressExtractor(std::unique_ptr<const model::NotificationPublisher>&& pPublisher,
-			const model::ExtractorContextFactoryFunc & contextFactory, const AddressResolver& resolver)
+			const model::ExtractorContextFactoryFunc & contextFactory, const ResolverHandleFactory& resolver)
 			: m_pPublisher(std::move(pPublisher))
 			, m_extractorContextFactory(contextFactory)
-			, m_addressResolver(resolver)
+			, m_resolverHandleFactory(resolver)
 	{}
 
 	void AddressExtractor::extract(model::TransactionInfo& transactionInfo) const {
@@ -36,7 +35,7 @@ namespace catapult { namespace addressextraction {
 			return;
 		
 		auto addresses = model::ExtractAddresses(*transactionInfo.pEntity, transactionInfo.EntityHash,
-			transactionInfo.AssociatedHeight, *m_pPublisher, m_extractorContextFactory(), m_addressResolver);
+			transactionInfo.AssociatedHeight, *m_pPublisher, m_extractorContextFactory(), m_resolverHandleFactory());
 		
 		transactionInfo.OptionalExtractedAddresses = std::make_shared<model::UnresolvedAddressSet>(std::move(addresses));
 	}
@@ -51,7 +50,7 @@ namespace catapult { namespace addressextraction {
 			return;
 		
 		auto addresses = model::ExtractAddresses(transactionElement.Transaction, transactionElement.EntityHash, height,
-			*m_pPublisher, m_extractorContextFactory(), m_addressResolver);
+			*m_pPublisher, m_extractorContextFactory(), m_resolverHandleFactory());
 		
 		transactionElement.OptionalExtractedAddresses = std::make_shared<model::UnresolvedAddressSet>(std::move(addresses));
 	}

--- a/extensions/addressextraction/src/AddressExtractor.h
+++ b/extensions/addressextraction/src/AddressExtractor.h
@@ -25,6 +25,7 @@
 #include "catapult/model/ContainerTypes.h"
 #include "catapult/model/ExtractorContext.h"
 #include "catapult/model/NotificationPublisher.h"
+#include "catapult/model/TransactionUtils.h"
 
 namespace catapult {
 	namespace model {
@@ -38,13 +39,13 @@ namespace catapult { namespace addressextraction {
 	/// Utility class for extracting addresses.
 	class AddressExtractor {
 	private:
-		using AddressResolver = std::function<Address (UnresolvedAddress)>;
+		using ResolverHandleFactory = std::function<util::ResolverContextHandle ()>;
 		
 	public:
 		/// Creates an extractor around \a pPublisher and \a contextFactory.
 		AddressExtractor(std::unique_ptr<const model::NotificationPublisher>&& pPublisher,
 				const model::ExtractorContextFactoryFunc & contextFactory,
-				const AddressResolver& resolver);
+				const ResolverHandleFactory& resolver);
 
 	public:
 		/// Extracts transaction addresses into \a transactionInfo.
@@ -62,7 +63,7 @@ namespace catapult { namespace addressextraction {
 	private:
 		std::unique_ptr<const model::NotificationPublisher> m_pPublisher;
 		model::ExtractorContextFactoryFunc m_extractorContextFactory;
-		AddressResolver m_addressResolver;
+		ResolverHandleFactory m_resolverHandleFactory;
 		
 	};
 }}

--- a/extensions/addressextraction/tests/AddressExtractorTests.cpp
+++ b/extensions/addressextraction/tests/AddressExtractorTests.cpp
@@ -33,17 +33,21 @@ namespace catapult { namespace addressextraction {
 
 	namespace {
 		// region TestContext
-
+		
 		class TestContext {
 		public:
 			TestContext()
 					: m_pNotificationPublisher(std::make_unique<mocks::MockNotificationPublisher>())
 					, m_notificationPublisher(*m_pNotificationPublisher)
 					, m_extractor(std::move(m_pNotificationPublisher), [](){ return model::ExtractorContext(); }
-					, [](UnresolvedAddress address){
-						Address resolvedAddress;
-						std::memcpy(resolvedAddress.data(), address.data(), address.size());
-						return resolvedAddress;
+					,  []() {
+						return util::ResolverContextHandle(
+							[](){
+								return test::CoreSystemCacheFactory::Create().createView().toReadOnly();
+							},
+							[](auto&){
+								return test::CreateResolverContextXor();
+							});
 					})
 			{}
 

--- a/extensions/addressextraction/tests/test/AddressExtractionSubscriberTestContext.h
+++ b/extensions/addressextraction/tests/test/AddressExtractionSubscriberTestContext.h
@@ -44,12 +44,16 @@ namespace catapult { namespace test {
 				, m_pNotificationPublisher(std::make_unique<mocks::MockNotificationPublisher>())
 				, m_notificationPublisher(*m_pNotificationPublisher)
 				, m_extractor(std::move(m_pNotificationPublisher), [](){ return model::ExtractorContext(); }
-				, [](UnresolvedAddress address){
-					Address resolvedAddress;
-					std::memcpy(resolvedAddress.data(), address.data(), address.size());
-					return resolvedAddress;
-				})
-		{}
+				, []() {
+					return util::ResolverContextHandle(
+		              [](){
+			              return test::CoreSystemCacheFactory::Create().createView().toReadOnly();
+		              },
+		              [](auto&){
+			              return test::CreateResolverContextXor();
+		              });
+	              }) {
+		}
 
 	public:
 		/// Asserts that \a action results in no extracted addresses.

--- a/src/catapult/model/TransactionUtils.cpp
+++ b/src/catapult/model/TransactionUtils.cpp
@@ -82,12 +82,16 @@ namespace catapult { namespace model {
 		
 	UnresolvedAddressSet ExtractAddresses(const Transaction& transaction, const Hash256& hash, const Height& height,
 	                                      const NotificationPublisher& notificationPublisher, const ExtractorContext& extractorContext,
-	                                      const AddressResolver& resolver) {
+	                                      const util::ResolverContextHandle& resolverHandle) {
 		UnresolvedAddressSet newSet;
 		UnresolvedAddressSet addresses = ExtractAddresses(transaction, hash, height, notificationPublisher, extractorContext);
+		auto cache = resolverHandle.CacheFactory();
+		auto resolver = resolverHandle.ResolverFactory(cache);
+		
 		for (const auto& address : addresses) {
-			auto resolved = resolver(address);
+			auto resolved = resolver.resolve(address);
 			newSet.insert(extensions::CopyToUnresolvedAddress(resolved));
+			newSet.insert(address);
 		}
 		return newSet;
 	}

--- a/src/catapult/model/TransactionUtils.h
+++ b/src/catapult/model/TransactionUtils.h
@@ -23,14 +23,28 @@
 #include "ExtractorContext.h"
 #include "ResolverContext.h"
 #include <functional>
+#include "src/catapult/cache/CatapultCacheView.h"
+#include "src/catapult/cache/ReadOnlyCatapultCache.h"
 
 namespace catapult {
 	namespace model {
 		class NotificationPublisher;
 		struct Transaction;
 	}
-	namespace {
-		using AddressResolver = std::function<Address (UnresolvedAddress)>;
+	
+	namespace util {
+		
+		using ReadOnlyCacheFactory = std::function<cache::ReadOnlyCatapultCache()>;
+		using ResolverContextFactory = std::function<model::ResolverContext(cache::ReadOnlyCatapultCache&)>;
+		
+		struct ResolverContextHandle {
+			ReadOnlyCacheFactory CacheFactory;
+			ResolverContextFactory ResolverFactory;
+			ResolverContextHandle(const ReadOnlyCacheFactory& cacheFactory, const ResolverContextFactory& resolverFactory)
+				: CacheFactory(cacheFactory)
+				, ResolverFactory(resolverFactory){
+			}
+		};
 	}
 }
 
@@ -42,5 +56,5 @@ namespace catapult { namespace model {
 		
 	/// Extracts all addresses that are involved in \a transaction at \a height with \a hash using \a notificationPublisher and \a extractorContext and \a resolverContext
 	UnresolvedAddressSet ExtractAddresses(const Transaction& transaction, const Hash256& hash, const Height& height,
-			const NotificationPublisher& notificationPublisher, const ExtractorContext& extractorContext, const  AddressResolver& resolverContext);
+			const NotificationPublisher& notificationPublisher, const ExtractorContext& extractorContext, const util::ResolverContextHandle& resolverHandle);
 }}

--- a/tests/catapult/model/TransactionUtilsTests.cpp
+++ b/tests/catapult/model/TransactionUtilsTests.cpp
@@ -94,12 +94,7 @@ namespace catapult { namespace model {
 			MockNotificationPublisher notificationPublisher(mode);
 			
 			// Act:
-			auto addresses = ExtractAddresses(*pTransaction, Hash256{}, Height(), notificationPublisher,model::ExtractorContext(),
-				[](UnresolvedAddress address){
-					Address resolvedAddress;
-		            std::memcpy(resolvedAddress.data(), address.data(), address.size());
-		            return resolvedAddress;
-			});
+			auto addresses = ExtractAddresses(*pTransaction, Hash256{}, Height(), notificationPublisher,model::ExtractorContext());
 			
 			// Assert:
 			EXPECT_EQ(2u, addresses.size());


### PR DESCRIPTION
Added access to address resolver as a function callback to AddressExtractor.
The reason is, ResolverContext needs readonly cache and should have valid scope when resolver is used. The only way to create cache is thru bootstrapper as well, if we return ResolverContext instead, the cache created will be lost when function exist. Therefore I decided it is better that it will be resolved in the callback instead.
Also the resolve of address is in TransactionUtils.cpp function ExtractAddresses() instead in AddressExtractor.cpp where all functions are marked as const and does not allow changes. 
It basically resolved after address is extracted by AddressColector.
