### PR TITLE
Bugfix for Hash/Secret lock transactions with Delegated Harvesters (task#5pm2hb)

### DIFF
--- a/plugins/txes/lock_hash/src/model/HashLockNotifications.h
+++ b/plugins/txes/lock_hash/src/model/HashLockNotifications.h
@@ -89,8 +89,8 @@ namespace catapult { namespace model {
 
 	public:
 		/// Creates hash lock notification around \a signer, \a mosaic, \a duration and \a hash.
-		HashLockNotification(const Key& signer, const UnresolvedMosaic& mosaic, BlockDuration duration, const Hash256& hash)
-				: BaseLockNotification(signer, &mosaic, 1, duration)
+		HashLockNotification(const Key& signer, const UnresolvedMosaic& mosaic, BlockDuration duration, const Hash256& hash, const VersionType& version = 1)
+				: BaseLockNotification(signer, &mosaic, 1, duration, version)
 				, Hash(hash)
 		{}
 
@@ -98,4 +98,5 @@ namespace catapult { namespace model {
 		/// Hash.
 		const Hash256& Hash;
 	};
+	
 }}

--- a/plugins/txes/lock_hash/src/observers/HashLockObserver.cpp
+++ b/plugins/txes/lock_hash/src/observers/HashLockObserver.cpp
@@ -28,8 +28,8 @@ namespace catapult { namespace observers {
 	using Notification = model::HashLockNotification<1>;
 
 	namespace {
-		auto CreateLockInfo(const Key& account, MosaicId mosaicId, Height endHeight, const Notification& notification) {
-			return state::HashLockInfo(account, mosaicId, notification.MosaicsPtr->Amount, endHeight, notification.Hash);
+		auto CreateLockInfo(const Key& account, MosaicId mosaicId, Height endHeight, const Notification& notification, const VersionType& version) {
+			return state::HashLockInfo(account, mosaicId, notification.MosaicsPtr->Amount, endHeight, notification.Hash, version);
 		}
 	}
 
@@ -38,7 +38,7 @@ namespace catapult { namespace observers {
 		if (NotifyMode::Commit == context.Mode) {
 			auto endHeight = context.Height + Height(notification.Duration.unwrap());
 			auto mosaicId = context.Resolvers.resolve(notification.MosaicsPtr->MosaicId);
-			cache.insert(CreateLockInfo(notification.Signer, mosaicId, endHeight, notification));
+			cache.insert(CreateLockInfo(notification.Signer, mosaicId, endHeight, notification, notification.Version));
 
 			auto receiptType = model::Receipt_Type_LockHash_Created;
 			model::BalanceChangeReceipt receipt(receiptType, notification.Signer, mosaicId, notification.MosaicsPtr->Amount);

--- a/plugins/txes/lock_hash/src/plugins/HashLockTransactionPlugin.cpp
+++ b/plugins/txes/lock_hash/src/plugins/HashLockTransactionPlugin.cpp
@@ -33,12 +33,13 @@ namespace catapult { namespace plugins {
 		void Publish(const TTransaction& transaction, const Height&, NotificationSubscriber& sub) {
 			switch (transaction.EntityVersion()) {
 			case 1:
+			case 2:
 				sub.notify(HashLockDurationNotification<1>(transaction.Duration));
 				sub.notify(HashLockMosaicNotification<1>(transaction.Mosaic));
 				sub.notify(BalanceDebitNotification<1>(transaction.Signer, transaction.Mosaic.MosaicId, transaction.Mosaic.Amount));
-				sub.notify(HashLockNotification<1>(transaction.Signer, transaction.Mosaic, transaction.Duration, transaction.Hash));
+				sub.notify(HashLockNotification<1>(transaction.Signer, transaction.Mosaic, transaction.Duration, transaction.Hash, transaction.EntityVersion()));
 				break;
-
+			
 			default:
 				CATAPULT_LOG(debug) << "invalid version of HashLockTransaction: " << transaction.EntityVersion();
 			}

--- a/plugins/txes/lock_hash/src/state/HashLockInfo.h
+++ b/plugins/txes/lock_hash/src/state/HashLockInfo.h
@@ -36,8 +36,9 @@ namespace catapult { namespace state {
 				catapult::MosaicId mosaicId,
 				catapult::Amount amount,
 				catapult::Height height,
-				const Hash256& hash)
-				: LockInfo(account, mosaicId, amount, height)
+				const Hash256& hash,
+				const VersionType& version = 1)
+				: LockInfo(account, mosaicId, amount, height, version)
 				, Hash(hash)
 		{}
 

--- a/plugins/txes/lock_hash/src/state/HashLockInfoSerializer.h
+++ b/plugins/txes/lock_hash/src/state/HashLockInfoSerializer.h
@@ -34,5 +34,5 @@ namespace catapult { namespace state {
 	};
 
 	/// Policy for saving and loading hash lock info data.
-	struct HashLockInfoSerializer : public LockInfoSerializer<HashLockInfo, HashLockInfoExtendedDataSerializer, 1> {};
+	struct HashLockInfoSerializer : public LockInfoSerializer<HashLockInfo, HashLockInfoExtendedDataSerializer, 3> {};
 }}

--- a/plugins/txes/lock_hash/tests/observers/ExpiredHashLockInfoObserverTests.cpp
+++ b/plugins/txes/lock_hash/tests/observers/ExpiredHashLockInfoObserverTests.cpp
@@ -64,6 +64,6 @@ namespace catapult { namespace observers {
 			}
 		};
 	}
-
-	DEFINE_EXPIRED_LOCK_INFO_OBSERVER_TESTS(ExpiredHashLockInfoTraits)
+		
+	DEFINE_EXPIRED_LOCK_INFO_WITH_LINKED_OBSERVER_TESTS(ExpiredHashLockInfoTraits)
 }}

--- a/plugins/txes/lock_secret/src/model/SecretLockNotifications.h
+++ b/plugins/txes/lock_secret/src/model/SecretLockNotifications.h
@@ -102,8 +102,9 @@ namespace catapult { namespace model {
 				BlockDuration duration,
 				LockHashAlgorithm hashAlgorithm,
 				const Hash256& secret,
-				const UnresolvedAddress& recipient)
-				: BaseLockNotification(signer, &mosaic, 1, duration)
+				const UnresolvedAddress& recipient,
+				const VersionType& version = 1)
+				: BaseLockNotification(signer, &mosaic, 1, duration, version)
 				, HashAlgorithm(hashAlgorithm)
 				, Secret(secret)
 				, Recipient(recipient)

--- a/plugins/txes/lock_secret/src/observers/SecretLockObserver.cpp
+++ b/plugins/txes/lock_secret/src/observers/SecretLockObserver.cpp
@@ -33,7 +33,8 @@ namespace catapult { namespace observers {
 				MosaicId mosaicId,
 				Height endHeight,
 				const Notification& notification,
-				const model::ResolverContext& resolvers) {
+				const model::ResolverContext& resolvers,
+				const VersionType& version) {
 			state::SecretLockInfo lockInfo(
 					account,
 					mosaicId,
@@ -41,7 +42,8 @@ namespace catapult { namespace observers {
 					endHeight,
 					notification.HashAlgorithm,
 					notification.Secret,
-					resolvers.resolve(notification.Recipient));
+					resolvers.resolve(notification.Recipient),
+					version);
 			lockInfo.CompositeHash = model::CalculateSecretLockInfoHash(lockInfo.Secret, lockInfo.Recipient);
 			return lockInfo;
 		}
@@ -52,7 +54,7 @@ namespace catapult { namespace observers {
 		if (NotifyMode::Commit == context.Mode) {
 			auto endHeight = context.Height + Height(notification.Duration.unwrap());
 			auto mosaicId = context.Resolvers.resolve(notification.MosaicsPtr->MosaicId);
-			cache.insert(CreateLockInfo(notification.Signer, mosaicId, endHeight, notification, context.Resolvers));
+			cache.insert(CreateLockInfo(notification.Signer, mosaicId, endHeight, notification, context.Resolvers, notification.Version));
 
 			auto receiptType = model::Receipt_Type_LockSecret_Created;
 			model::BalanceChangeReceipt receipt(receiptType, notification.Signer, mosaicId, notification.MosaicsPtr->Amount);

--- a/plugins/txes/lock_secret/src/plugins/SecretLockTransactionPlugin.cpp
+++ b/plugins/txes/lock_secret/src/plugins/SecretLockTransactionPlugin.cpp
@@ -33,6 +33,7 @@ namespace catapult { namespace plugins {
 		void Publish(const TTransaction& transaction, const Height&, NotificationSubscriber& sub) {
 			switch (transaction.EntityVersion()) {
 			case 1:
+			case 2:
 				sub.notify(AccountAddressNotification<1>(transaction.Recipient));
 				sub.notify(SecretLockDurationNotification<1>(transaction.Duration));
 				sub.notify(SecretLockHashAlgorithmNotification<1>(transaction.HashAlgorithm));
@@ -44,7 +45,8 @@ namespace catapult { namespace plugins {
 					transaction.Duration,
 					transaction.HashAlgorithm,
 					transaction.Secret,
-					transaction.Recipient));
+					transaction.Recipient,
+					transaction.EntityVersion()));
 				break;
 
 			default:

--- a/plugins/txes/lock_secret/src/state/SecretLockInfo.h
+++ b/plugins/txes/lock_secret/src/state/SecretLockInfo.h
@@ -40,8 +40,9 @@ namespace catapult { namespace state {
 				catapult::Height height,
 				model::LockHashAlgorithm hashAlgorithm,
 				const Hash256& secret,
-				const catapult::Address& recipient)
-				: LockInfo(account, mosaicId, amount, height)
+				const catapult::Address& recipient,
+				const VersionType& version = 1)
+				: LockInfo(account, mosaicId, amount, height, version)
 				, HashAlgorithm(hashAlgorithm)
 				, Secret(secret)
 				, Recipient(recipient)

--- a/plugins/txes/lock_secret/src/state/SecretLockInfoSerializer.h
+++ b/plugins/txes/lock_secret/src/state/SecretLockInfoSerializer.h
@@ -34,5 +34,5 @@ namespace catapult { namespace state {
 	};
 
 	/// Policy for saving and loading secret lock info data.
-	struct SecretLockInfoSerializer : public LockInfoSerializer<SecretLockInfo, SecretLockInfoExtendedDataSerializer, 1> {};
+	struct SecretLockInfoSerializer : public LockInfoSerializer<SecretLockInfo, SecretLockInfoExtendedDataSerializer, 3> {};
 }}

--- a/plugins/txes/lock_secret/tests/observers/ExpiredSecretLockInfoObserverTests.cpp
+++ b/plugins/txes/lock_secret/tests/observers/ExpiredSecretLockInfoObserverTests.cpp
@@ -63,6 +63,6 @@ namespace catapult { namespace observers {
 			}
 		};
 	}
-
-	DEFINE_EXPIRED_LOCK_INFO_OBSERVER_TESTS(ExpiredSecretLockInfoTraits)
+	
+	DEFINE_EXPIRED_LOCK_INFO_WITH_LINKED_OBSERVER_TESTS(ExpiredSecretLockInfoTraits)
 }}

--- a/plugins/txes/lock_shared/src/model/LockNotifications.h
+++ b/plugins/txes/lock_shared/src/model/LockNotifications.h
@@ -44,12 +44,13 @@ namespace catapult { namespace model {
 	struct BaseLockNotification : public Notification {
 	protected:
 		/// Creates base lock notification around \a signer, \a mosaic and \a duration.
-		BaseLockNotification(const Key& signer, const UnresolvedMosaic* pMosaics, uint8_t mosaicCount, BlockDuration duration)
+		BaseLockNotification(const Key& signer, const UnresolvedMosaic* pMosaics, uint8_t mosaicCount, BlockDuration duration, const VersionType& version = 1)
 				: Notification(TDerivedNotification::Notification_Type, sizeof(TDerivedNotification))
 				, Signer(signer)
 				, MosaicsPtr(pMosaics)
 				, MosaicCount(mosaicCount)
 				, Duration(duration)
+				, Version(version)
 		{}
 
 	public:
@@ -64,5 +65,8 @@ namespace catapult { namespace model {
 
 		/// Lock duration.
 		BlockDuration Duration;
+		
+		/// notification version
+		VersionType Version;
 	};
 }}

--- a/plugins/txes/lock_shared/src/state/LockInfo.h
+++ b/plugins/txes/lock_shared/src/state/LockInfo.h
@@ -37,18 +37,24 @@ namespace catapult { namespace state {
 	struct LockInfo {
 	protected:
 		/// Creates a default lock info.
-		LockInfo() : Status(LockStatus::Unused)
+		LockInfo()
+			: Version(1)
+			, Status(LockStatus::Unused)
 		{}
 
 		/// Creates a lock info around \a account, \a mosaicId, \a amount and \a height.
-		explicit LockInfo(const Key& account, MosaicId mosaicId, Amount amount, Height height)
-				: Account(account)
+		explicit LockInfo(const Key& account, MosaicId mosaicId, Amount amount, Height height, const VersionType& version = 1)
+				: Version(version)
+				, Account(account)
 				, Mosaics{{mosaicId,  amount}}
 				, Height(height)
 				, Status(LockStatus::Unused)
 		{}
 
 	public:
+		/// Entry data version
+		VersionType Version;
+		
 		/// Account.
 		Key Account;
 
@@ -59,7 +65,7 @@ namespace catapult { namespace state {
 
 		/// Flag indicating whether or not the lock was already used.
 		LockStatus Status;
-
+		
 	public:
 		/// Returns status of lock.
 		constexpr LockStatus status() const {

--- a/plugins/txes/lock_shared/src/state/LockInfoSerializer.h
+++ b/plugins/txes/lock_shared/src/state/LockInfoSerializer.h
@@ -33,13 +33,13 @@ namespace catapult { namespace state {
 	template<typename TLockInfo, typename TLockInfoSerializer>
 	struct LockInfoSerializer<TLockInfo, TLockInfoSerializer, 1> {
 	public:
-		static constexpr VersionType Version = 1;
+		static constexpr VersionType LatestVersion = 2;
 
 	public:
 		/// Saves \a lockInfo to \a output.
 		static void Save(const TLockInfo& lockInfo, io::OutputStream& output){
 			// write version
-			io::Write32(output, Version);
+			io::Write32(output, lockInfo.Version);
 
 			io::Write(output, lockInfo.Account);
 			io::Write(output, lockInfo.Mosaics.begin()->first);
@@ -53,10 +53,12 @@ namespace catapult { namespace state {
 		static TLockInfo Load(io::InputStream& input){
 			// read version
 			VersionType version = io::Read32(input);
-			if (version != Version)
-				CATAPULT_THROW_RUNTIME_ERROR_2("invalid version of LockInfo (expected, actual)", Version, version);
+			if (version <= 0 || version > LatestVersion)
+				CATAPULT_THROW_RUNTIME_ERROR_1("invalid version of LockInfo ", version);
 
 			TLockInfo lockInfo;
+			
+			lockInfo.Version = version;
 			io::Read(input, lockInfo.Account);
 			auto mosaicId = MosaicId{io::Read64(input)};
 			auto amount = Amount{io::Read64(input)};

--- a/resources/supported-entities.json
+++ b/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Modify_Contract",

--- a/resources/supported-entities.json
+++ b/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Modify_Contract",

--- a/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Modify_Contract",

--- a/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Modify_Contract",

--- a/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1, 2]
+			"supportedVersions": [2]
 		},
 		{
 			"name": "Modify_Contract",

--- a/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
@@ -38,7 +38,7 @@
 		{
 			"name": "Hash_Lock",
 			"type": "16712",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Network_Config",
@@ -73,7 +73,7 @@
 		{
 			"name": "Secret_Lock",
 			"type": "16722",
-			"supportedVersions": [1]
+			"supportedVersions": [1, 2]
 		},
 		{
 			"name": "Modify_Contract",


### PR DESCRIPTION
… Added version in LockInfo entry and notifications. Upgraded version of Hashlock and secret lock to support version 2

change notes:
1. I did not create a different version (no version 2) of notification for HashLockNotification and SecretLockNotification, but instead I added a new member "Version" in the base class BaseLockNotification, I thought it is simpler this way, since notification is just handled within the chain and will not matter for old blocks. 
Also adding new version of notification means adding new observer for notification which only differs in setting the version of the cache entry, it will be a redundant observer because both old and new observer will have to set version anyway.

Also, Version information is already stored in cache anyway, we just need a variable in the chain that handles it.
		
2. The new attribute "Version" added in lockInfo entry is only changed for LockInfoSerializer version 1, the version 2 of serialzer which is use for Operation plugin was not modified. however Version attribute of lockinfo defaults to 1 for all.

 