### PR TITLE
Bug: cannot insert element with height X when cache height is Y"

### DIFF
--- a/src/catapult/cache_core/BlockDifficultyCacheSubCachePlugin.cpp
+++ b/src/catapult/cache_core/BlockDifficultyCacheSubCachePlugin.cpp
@@ -28,8 +28,13 @@ namespace catapult { namespace cache {
 		io::Write64(output, delta.size());
 
 		auto pIterableView = delta.tryMakeIterableView();
-		for (const auto& value : *pIterableView)
-			BlockDifficultyCacheStorage::Save(value, output);
+		for (auto iter = pIterableView->begin(); iter != pIterableView->end();) {
+			BlockDifficultyCacheStorage::Save(*iter, output);
+			auto prevIter = iter;
+			++iter;
+			if (iter != pIterableView->end() && prevIter->BlockHeight >= iter->BlockHeight)
+				CATAPULT_THROW_RUNTIME_ERROR("next block difficulty height can't be lower");
+		}
 
 		output.flush();
 	}


### PR DESCRIPTION
Added validation that order of difficulty is right.
Integrated the change from NEM to prioritize original elements in iterable view. In case of block difficulty it helps to order them right by height(we can't modify difficulty at height X if we didn't modify on previous heights).