### PR TITLE
Bug with unordered receipts during end of billing period

### DIFF
--- a/extensions/mongo/src/MongoBlockStorage.cpp
+++ b/extensions/mongo/src/MongoBlockStorage.cpp
@@ -28,6 +28,7 @@
 #include "mappers/ResolutionStatementMapper.h"
 #include "mappers/TransactionMapper.h"
 #include "mappers/TransactionStatementMapper.h"
+#include "mappers/PublicKeyStatementMapper.h"
 
 using namespace bsoncxx::builder::stream;
 
@@ -115,7 +116,15 @@ namespace catapult { namespace mongo {
 			futures.emplace_back(bulkWriter.bulkInsert("mosaicResolutionStatements", blockStatement.MosaicResolutionStatements, [height](
 					const auto& pair,
 					auto) {
-				return mappers::ToDbModel(height, pair.second);
+			  return mappers::ToDbModel(height, pair.second);
+			}));
+
+			// mosaic resolution statements
+			numExpectedInserts.emplace_back(blockStatement.PublicKeyStatements.size());
+			futures.emplace_back(bulkWriter.bulkInsert("publicKeyStatements", blockStatement.PublicKeyStatements, [height, &registry](
+					const auto& pair,
+					auto) {
+			  return mappers::ToDbModel(height, pair.second, registry);
 			}));
 
 			auto statementsFuture = thread::when_all(std::move(futures)).then([height, numExpectedInserts, &errorPolicy](
@@ -233,6 +242,7 @@ namespace catapult { namespace mongo {
 				DropDocuments(m_database, "transactionStatements", "height", height);
 				DropDocuments(m_database, "addressResolutionStatements", "height", height);
 				DropDocuments(m_database, "mosaicResolutionStatements", "height", height);
+				DropDocuments(m_database, "publicKeyStatements", "height", height);
 			}
 
 		private:

--- a/extensions/mongo/src/mappers/PublicKeyStatementMapper.cpp
+++ b/extensions/mongo/src/mappers/PublicKeyStatementMapper.cpp
@@ -1,0 +1,45 @@
+/**
+*** Copyright 2020 ProximaX Limited. All rights reserved.
+*** Use of this source code is governed by the Apache 2.0
+*** license that can be found in the LICENSE file.
+**/
+
+#include "PublicKeyStatementMapper.h"
+#include "ReceiptMapper.h"
+#include "catapult/model/Statement.h"
+
+namespace catapult { namespace mongo { namespace mappers {
+
+	namespace {
+		void StreamReceipts(
+				bson_stream::document& builder,
+				const model::PublicKeyStatement& statement,
+				const MongoReceiptRegistry& receiptRegistry) {
+			auto receiptsArray = builder << "receipts" << bson_stream::open_array;
+			for (auto i = 0u; i < statement.size(); ++i) {
+				const auto& receipt = statement.receiptAt(i);
+				bsoncxx::builder::stream::document receiptBuilder;
+				StreamReceipt(receiptBuilder, receipt, receiptRegistry);
+				receiptsArray << receiptBuilder;
+			}
+
+			receiptsArray << bson_stream::close_array;
+		}
+	}
+
+	bsoncxx::document::value ToDbModel(
+			Height height,
+			const model::PublicKeyStatement& statement,
+			const MongoReceiptRegistry& receiptRegistry) {
+		bson_stream::document builder;
+		builder
+				<< "height" << ToInt64(height)
+				<< "source" << bson_stream::open_document
+				<< "primaryId" << static_cast<int32_t>(statement.source().PrimaryId)
+				<< "secondaryId" << static_cast<int32_t>(statement.source().SecondaryId)
+				<< bson_stream::close_document;
+
+		StreamReceipts(builder, statement, receiptRegistry);
+		return builder << bson_stream::finalize;
+	}
+}}}

--- a/extensions/mongo/src/mappers/PublicKeyStatementMapper.h
+++ b/extensions/mongo/src/mappers/PublicKeyStatementMapper.h
@@ -1,0 +1,23 @@
+/**
+*** Copyright 2020 ProximaX Limited. All rights reserved.
+*** Use of this source code is governed by the Apache 2.0
+*** license that can be found in the LICENSE file.
+**/
+
+#pragma once
+#include "MapperInclude.h"
+#include "MapperUtils.h"
+#include "src/catapult/model/Statement.h"
+
+namespace catapult {
+	namespace mongo { class MongoReceiptRegistry; }
+}
+
+namespace catapult { namespace mongo { namespace mappers {
+
+	/// Maps a \a statement at \a height to the corresponding db model value using \a receiptRegistry for mapping derived receipt types.
+	bsoncxx::document::value ToDbModel(
+			Height height,
+			const model::PublicKeyStatement& statement,
+			const MongoReceiptRegistry& receiptRegistry);
+}}}

--- a/plugins/txes/exchange/src/cache/ExchangeCacheTypes.h
+++ b/plugins/txes/exchange/src/cache/ExchangeCacheTypes.h
@@ -62,7 +62,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<Key, Height, utils::ArrayHasher<Key>>;
+			using ValueType = utils::OrderedIdentifierGroup<Key, Height>;
 			using Serializer = ExchangeHeightGroupingSerializer;
 
 		public:

--- a/plugins/txes/lock_shared/src/cache/LockInfoCacheTypes.h
+++ b/plugins/txes/lock_shared/src/cache/LockInfoCacheTypes.h
@@ -39,7 +39,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<IdentifierType, Height, utils::ArrayHasher<IdentifierType>>;
+			using ValueType = utils::UnorderedIdentifierGroup<IdentifierType, Height, utils::ArrayHasher<IdentifierType>>;
 			using Serializer = IdentifierGroupSerializer<HeightGroupingTypesDescriptor>;
 
 		public:

--- a/plugins/txes/metadata/src/cache/MetadataCacheTypes.h
+++ b/plugins/txes/metadata/src/cache/MetadataCacheTypes.h
@@ -73,7 +73,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<Hash256, Height, utils::ArrayHasher<Hash256>>;
+			using ValueType = utils::UnorderedIdentifierGroup<Hash256, Height, utils::ArrayHasher<Hash256>>;
 			using Serializer = MetadataHeightGroupingSerializer;
 
 		public:

--- a/plugins/txes/mosaic/src/cache/MosaicCacheTypes.h
+++ b/plugins/txes/mosaic/src/cache/MosaicCacheTypes.h
@@ -81,7 +81,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<MosaicId, Height, utils::BaseValueHasher<MosaicId>>;
+			using ValueType = utils::UnorderedIdentifierGroup<MosaicId, Height, utils::BaseValueHasher<MosaicId>>;
 			using Serializer = MosaicHeightGroupingSerializer;
 
 		public:

--- a/plugins/txes/namespace/src/cache/NamespaceCacheTypes.h
+++ b/plugins/txes/namespace/src/cache/NamespaceCacheTypes.h
@@ -109,7 +109,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<NamespaceId, Height, utils::BaseValueHasher<NamespaceId>>;
+			using ValueType = utils::UnorderedIdentifierGroup<NamespaceId, Height, utils::BaseValueHasher<NamespaceId>>;
 			using Serializer = NamespaceHeightGroupingSerializer;
 
 		public:

--- a/plugins/txes/service/src/cache/DriveCacheTypes.h
+++ b/plugins/txes/service/src/cache/DriveCacheTypes.h
@@ -60,7 +60,7 @@ namespace catapult { namespace cache {
 		struct HeightGroupingTypesDescriptor {
 		public:
 			using KeyType = Height;
-			using ValueType = utils::IdentifierGroup<Key, Height, utils::ArrayHasher<Key>>;
+			using ValueType = utils::OrderedIdentifierGroup<Key, Height>;
 			using Serializer = DriveHeightGroupingSerializer;
 
 		public:

--- a/src/catapult/utils/IdentifierGroup.h
+++ b/src/catapult/utils/IdentifierGroup.h
@@ -19,13 +19,14 @@
 **/
 
 #pragma once
+#include <set>
 #include <unordered_set>
 
 namespace catapult { namespace utils {
 
 	/// A group of identifiers that share a common (external) attribute.
 	template<typename TIdentifier, typename TGroupingKey, typename TIdentifierHasher>
-	class IdentifierGroup {
+	class UnorderedIdentifierGroup {
 	public:
 		/// Unordered set of identifiers.
 		using Identifiers = std::unordered_set<TIdentifier, TIdentifierHasher>;
@@ -35,7 +36,60 @@ namespace catapult { namespace utils {
 
 	public:
 		/// Creates a group around a given \a key.
-		explicit IdentifierGroup(const TGroupingKey& key) : m_key(key)
+		explicit UnorderedIdentifierGroup(const TGroupingKey& key) : m_key(key)
+		{}
+
+	public:
+		/// Gets the grouping key.
+		const TGroupingKey& key() const {
+			return m_key;
+		}
+
+		/// Gets the identifiers.
+		const Identifiers& identifiers() const {
+			return m_identifiers;
+		}
+
+	public:
+		/// Returns \c true if the group is empty, \c false otherwise.
+		bool empty() const {
+			return m_identifiers.empty();
+		}
+
+		/// Gets the number of identifiers in the group.
+		size_t size() const {
+			return m_identifiers.size();
+		}
+
+	public:
+		/// Adds \a identifier to the group.
+		void add(const TIdentifier& identifier) {
+			m_identifiers.insert(identifier);
+		}
+
+		/// Removes \a identifier from the group.
+		void remove(const TIdentifier& identifier) {
+			m_identifiers.erase(identifier);
+		}
+
+	private:
+		TGroupingKey m_key;
+		Identifiers m_identifiers;
+	};
+
+	/// An ordered group of identifiers that share a common (external) attribute.
+	template<typename TIdentifier, typename TGroupingKey>
+	class OrderedIdentifierGroup {
+	public:
+		/// Ordered set of identifiers.
+		using Identifiers = std::set<TIdentifier>;
+
+		/// Type of grouping key.
+		using GroupingKeyType = TGroupingKey;
+
+	public:
+		/// Creates a group around a given \a key.
+		explicit OrderedIdentifierGroup(const TGroupingKey& key) : m_key(key)
 		{}
 
 	public:

--- a/tests/catapult/cache/IdentifierGroupSerializerTests.cpp
+++ b/tests/catapult/cache/IdentifierGroupSerializerTests.cpp
@@ -31,7 +31,7 @@ namespace catapult { namespace cache {
 		struct TimeBasedDescriptor {
 		public:
 			using KeyType = Timestamp;
-			using ValueType = utils::IdentifierGroup<Height, Timestamp, utils::BaseValueHasher<Height>>;
+			using ValueType = utils::UnorderedIdentifierGroup<Height, Timestamp, utils::BaseValueHasher<Height>>;
 		};
 
 		using Serializer = IdentifierGroupSerializer<TimeBasedDescriptor>;

--- a/tests/catapult/utils/IdentifierGroupTests.cpp
+++ b/tests/catapult/utils/IdentifierGroupTests.cpp
@@ -31,7 +31,7 @@ namespace catapult { namespace utils {
 		using TestKey = BaseValue<uint64_t, TestKey_tag>;
 
 		// Height grouped by TestKey
-		using TestIdentifierGroup = IdentifierGroup<Height, TestKey, BaseValueHasher<Height>>;
+		using TestIdentifierGroup = UnorderedIdentifierGroup<Height, TestKey, BaseValueHasher<Height>>;
 
 		void AssertIdentifiers(const TestIdentifierGroup::Identifiers& ids, const std::vector<Height::ValueType>& expectedIds) {
 			ASSERT_EQ(expectedIds.size(), ids.size());

--- a/tests/test/cache/TestCacheTypes.h
+++ b/tests/test/cache/TestCacheTypes.h
@@ -32,14 +32,14 @@ namespace catapult { namespace test {
 		// region TestHeightGroupedCacheDescriptor
 
 		/// Identifier group that groups int values by height.
-		class TestIdentifierGroup : public utils::IdentifierGroup<int, Height, std::hash<int>> {
+		class TestIdentifierGroup : public utils::UnorderedIdentifierGroup<int, Height, std::hash<int>> {
 		public:
 #ifdef _MSC_VER
 			TestIdentifierGroup() : TestIdentifierGroup(Height())
 			{}
 #endif
 
-			using utils::IdentifierGroup<int, Height, std::hash<int>>::IdentifierGroup;
+			using utils::UnorderedIdentifierGroup<int, Height, std::hash<int>>::UnorderedIdentifierGroup;
 		};
 
 		/// Cache descriptor for cache of values grouped by height.


### PR DESCRIPTION
Added a new OrderedIdentifierGroup which is using set inside instead of unordered_set. It is need for drive because during process of this set we are adding receipts. But if each node will have own order, they will not able to sync.

Also added printing public key statement to mongodb.