### PR TITLE
0.6.3 release: remove cleaning of drive entry

### DIFF
--- a/plugins/txes/service/src/cache/DriveCacheDelta.h
+++ b/plugins/txes/service/src/cache/DriveCacheDelta.h
@@ -90,7 +90,7 @@ namespace catapult { namespace cache {
 
         void prune(Height height, observers::ObserverContext&) {
             ForEachIdentifierWithGroup(*m_pDriveEntries, *m_pRemoveAtHeight, height, [&](state::DriveEntry& driveEntry) {
-                if (driveEntry.end() == height) {
+                if (driveEntry.end() == height && driveEntry.version() < 3) {
 					m_pDriveEntries->remove(driveEntry.key());
                 }
             });

--- a/plugins/txes/service/src/model/PrepareDriveTransaction.h
+++ b/plugins/txes/service/src/model/PrepareDriveTransaction.h
@@ -26,7 +26,7 @@ namespace catapult { namespace model {
 		{}
 
 	public:
-		DEFINE_TRANSACTION_CONSTANTS(Entity_Type_PrepareDrive, 2)
+		DEFINE_TRANSACTION_CONSTANTS(Entity_Type_PrepareDrive, 3)
 
 	public:
 		union {

--- a/plugins/txes/service/src/model/ServiceNotifications.h
+++ b/plugins/txes/service/src/model/ServiceNotifications.h
@@ -51,6 +51,9 @@ namespace catapult { namespace model {
 	/// Defines an end file download notification type.
 	DEFINE_NOTIFICATION_TYPE(All, Service, EndFileDownload_v1, 0x000D);
 
+	/// Defines a prepare drive notification type.
+	DEFINE_NOTIFICATION_TYPE(All, Service, Prepare_Drive_v2, 0x000E);
+
 	/// Notification of a drive prepare.
 	template<VersionType version>
 	struct PrepareDriveNotification;
@@ -93,6 +96,64 @@ namespace catapult { namespace model {
 
         /// Duration of drive.
         BlockDuration Duration;
+
+		/// Billing period of drive.
+		BlockDuration BillingPeriod;
+
+		/// Billing price of drive in storage units.
+		Amount BillingPrice;
+
+		/// The size of the drive.
+		uint64_t DriveSize;
+
+		/// The number of drive replicas.
+		uint16_t Replicas;
+
+		/// Minimal count of replicator to send transaction from name of drive.
+		uint16_t MinReplicators;
+
+		/// Percent of approves from replicators to apply transaction.
+		uint8_t PercentApprovers;
+	};
+
+	template<>
+	struct PrepareDriveNotification<2> : public Notification {
+	public:
+		/// Matching notification type.
+		static constexpr auto Notification_Type = Service_Prepare_Drive_v2_Notification;
+
+	public:
+		explicit PrepareDriveNotification(
+				const Key& drive,
+				const Key& owner,
+				const BlockDuration& duration,
+				const BlockDuration& billingPeriod,
+				const Amount& billingPrice,
+				uint64_t size,
+				uint16_t replicas,
+				uint16_t minReplicators,
+				uint8_t percentApprovers)
+				: Notification(Notification_Type, sizeof(PrepareDriveNotification<1>))
+				, DriveKey(drive)
+				, Owner(owner)
+				, Duration(duration)
+				, BillingPeriod(billingPeriod)
+				, BillingPrice(billingPrice)
+				, DriveSize(size)
+				, Replicas(replicas)
+				, MinReplicators(minReplicators)
+				, PercentApprovers(percentApprovers)
+		{}
+
+	public:
+		/// Public key of the drive multisig account.
+		Key DriveKey;
+
+		/// Public key of the drive owner.
+		Key Owner;
+
+		/// Duration of drive.
+		BlockDuration Duration;
 
 		/// Billing period of drive.
 		BlockDuration BillingPeriod;

--- a/plugins/txes/service/src/observers/Observers.h
+++ b/plugins/txes/service/src/observers/Observers.h
@@ -14,7 +14,10 @@
 namespace catapult { namespace observers {
 
 	/// Observes changes triggered by prepare drive notifications.
-	DECLARE_OBSERVER(PrepareDrive, model::PrepareDriveNotification<1>)();
+	DECLARE_OBSERVER(PrepareDriveV1, model::PrepareDriveNotification<1>)();
+
+	/// Observes changes triggered by prepare drive notifications.
+	DECLARE_OBSERVER(PrepareDriveV2, model::PrepareDriveNotification<2>)();
 
 	/// Observes changes triggered by drive file system notifications.
 	DECLARE_OBSERVER(DriveFileSystem, model::DriveFileSystemNotification<1>)(const MosaicId& streamingMosaicId);

--- a/plugins/txes/service/src/observers/PrepareDriveObserver.cpp
+++ b/plugins/txes/service/src/observers/PrepareDriveObserver.cpp
@@ -8,7 +8,7 @@
 
 namespace catapult { namespace observers {
 
-	DEFINE_OBSERVER(PrepareDrive, model::PrepareDriveNotification<1>, [](const auto& notification, ObserverContext& context) {
+	DEFINE_OBSERVER(PrepareDriveV1, model::PrepareDriveNotification<1>, [](const auto& notification, ObserverContext& context) {
 		auto& driveCache = context.Cache.sub<cache::DriveCache>();
 		if (NotifyMode::Commit == context.Mode) {
 			state::DriveEntry driveEntry(notification.DriveKey);
@@ -27,5 +27,27 @@ namespace catapult { namespace observers {
 			if (driveCache.contains(notification.DriveKey))
 				driveCache.remove(notification.DriveKey);
 		}
+	});
+
+	DEFINE_OBSERVER(PrepareDriveV2, model::PrepareDriveNotification<2>, [](const auto& notification, ObserverContext& context) {
+	  auto& driveCache = context.Cache.sub<cache::DriveCache>();
+	  if (NotifyMode::Commit == context.Mode) {
+		  state::DriveEntry driveEntry(notification.DriveKey);
+		  driveEntry.setVersion(3);
+		  SetDriveState(driveEntry, context, state::DriveState::NotStarted);
+		  driveEntry.setOwner(notification.Owner);
+		  driveEntry.setStart(context.Height);
+		  driveEntry.setDuration(notification.Duration);
+		  driveEntry.setBillingPeriod(notification.BillingPeriod);
+		  driveEntry.setBillingPrice(notification.BillingPrice);
+		  driveEntry.setSize(notification.DriveSize);
+		  driveEntry.setReplicas(notification.Replicas);
+		  driveEntry.setMinReplicators(notification.MinReplicators);
+		  driveEntry.setPercentApprovers(notification.PercentApprovers);
+		  driveCache.insert(driveEntry);
+	  } else {
+		  if (driveCache.contains(notification.DriveKey))
+			  driveCache.remove(notification.DriveKey);
+	  }
 	});
 }}

--- a/plugins/txes/service/src/plugins/PrepareDriveTransactionPlugin.cpp
+++ b/plugins/txes/service/src/plugins/PrepareDriveTransactionPlugin.cpp
@@ -20,32 +20,47 @@ namespace catapult { namespace plugins {
 			switch (transaction.EntityVersion()) {
 			case 1: {
 				sub.notify(PrepareDriveNotification<1>(
-					transaction.DriveKey,
-					transaction.Signer,
-					transaction.Duration,
-					transaction.BillingPeriod,
-					transaction.BillingPrice,
-					transaction.DriveSize,
-					transaction.Replicas,
-					transaction.MinReplicators,
-					transaction.PercentApprovers
+						transaction.DriveKey,
+						transaction.Signer,
+						transaction.Duration,
+						transaction.BillingPeriod,
+						transaction.BillingPrice,
+						transaction.DriveSize,
+						transaction.Replicas,
+						transaction.MinReplicators,
+						transaction.PercentApprovers
 				));
-                break;
+				break;
 			}
 
 			case 2: {
 				sub.notify(PrepareDriveNotification<1>(
-					transaction.Signer,
-					transaction.Owner,
-					transaction.Duration,
-					transaction.BillingPeriod,
-					transaction.BillingPrice,
-					transaction.DriveSize,
-					transaction.Replicas,
-					transaction.MinReplicators,
-					transaction.PercentApprovers
+						transaction.Signer,
+						transaction.Owner,
+						transaction.Duration,
+						transaction.BillingPeriod,
+						transaction.BillingPrice,
+						transaction.DriveSize,
+						transaction.Replicas,
+						transaction.MinReplicators,
+						transaction.PercentApprovers
 				));
-                break;
+				break;
+			}
+
+			case 3: {
+				sub.notify(PrepareDriveNotification<2>(
+						transaction.Signer,
+						transaction.Owner,
+						transaction.Duration,
+						transaction.BillingPeriod,
+						transaction.BillingPrice,
+						transaction.DriveSize,
+						transaction.Replicas,
+						transaction.MinReplicators,
+						transaction.PercentApprovers
+				));
+				break;
 			}
 
 

--- a/plugins/txes/service/src/plugins/ServicePlugin.cpp
+++ b/plugins/txes/service/src/plugins/ServicePlugin.cpp
@@ -157,7 +157,8 @@ namespace catapult { namespace plugins {
 
 		manager.addStatelessValidatorHook([](auto& builder) {
 			builder
-					.add(validators::CreatePrepareDriveArgumentsValidator())
+					.add(validators::CreatePrepareDriveArgumentsV1Validator())
+					.add(validators::CreatePrepareDriveArgumentsV2Validator())
 					.add(validators::CreateServicePluginConfigValidator())
 					.add(validators::CreateFailedBlockHashesValidator());
 		});
@@ -171,7 +172,8 @@ namespace catapult { namespace plugins {
                     .add(validators::CreateDriveFilesRewardValidator(immutableConfig.StreamingMosaicId))
 					.add(validators::CreateFilesDepositValidator())
 					.add(validators::CreateJoinToDriveValidator())
-					.add(validators::CreatePrepareDrivePermissionValidator())
+					.add(validators::CreatePrepareDrivePermissionV1Validator())
+					.add(validators::CreatePrepareDrivePermissionV2Validator())
 					.add(validators::CreateDriveFileSystemValidator())
 					.add(validators::CreateEndDriveValidator())
 					.add(validators::CreateMaxFilesOnDriveValidator())
@@ -183,7 +185,8 @@ namespace catapult { namespace plugins {
 
 		manager.addObserverHook([pConfigHolder, &immutableConfig](auto& builder) {
 			builder
-					.add(observers::CreatePrepareDriveObserver())
+					.add(observers::CreatePrepareDriveV1Observer())
+					.add(observers::CreatePrepareDriveV2Observer())
 					.add(observers::CreateDriveFileSystemObserver(immutableConfig.StreamingMosaicId))
 					.add(observers::CreateFilesDepositObserver())
 					.add(observers::CreateJoinToDriveObserver())

--- a/plugins/txes/service/src/state/DriveEntry.h
+++ b/plugins/txes/service/src/state/DriveEntry.h
@@ -372,7 +372,7 @@ namespace catapult { namespace state {
 	class DriveEntry : public DriveMixin {
 	public:
 		// Creates a drive entry around \a key.
-		explicit DriveEntry(const Key& key) : m_key(key)
+		explicit DriveEntry(const Key& key) : m_key(key), m_version(1)
 		{}
 
 	public:
@@ -381,7 +381,16 @@ namespace catapult { namespace state {
 			return m_key;
 		}
 
+		void setVersion(VersionType version) {
+			m_version = version;
+		}
+
+		VersionType version() const {
+			return m_version;
+		}
+
 	private:
 		Key m_key;
+		VersionType m_version;
 	};
 }}

--- a/plugins/txes/service/src/state/DriveEntrySerializer.cpp
+++ b/plugins/txes/service/src/state/DriveEntrySerializer.cpp
@@ -148,10 +148,10 @@ namespace catapult { namespace state {
 	}
 
 	void DriveEntrySerializer::Save(const DriveEntry& driveEntry, io::OutputStream& output) {
-		uint32_t version = 1;
+		auto version = driveEntry.version();
 
 		if (driveEntry.coowners().size() > 0) {
-			version = 2;
+			version = std::max(VersionType(2), version);
 		}
 
 		io::Write32(output, version);
@@ -190,12 +190,13 @@ namespace catapult { namespace state {
 	DriveEntry DriveEntrySerializer::Load(io::InputStream& input) {
 		// read version
 		VersionType version = io::Read32(input);
-		if (version > 2)
+		if (version > 3)
 			CATAPULT_THROW_RUNTIME_ERROR_1("invalid version of DriveEntry", version);
 
 		Key key;
 		input.read(key);
 		state::DriveEntry entry(key);
+		entry.setVersion(version);
 
 		entry.setState(static_cast<DriveState>(io::Read8(input)));
 

--- a/plugins/txes/service/src/validators/PrepareDriveArgumentsValidator.cpp
+++ b/plugins/txes/service/src/validators/PrepareDriveArgumentsValidator.cpp
@@ -8,9 +8,10 @@
 
 namespace catapult { namespace validators {
 
-	using Notification = model::PrepareDriveNotification<1>;
+	namespace {
 
-	DEFINE_STATELESS_VALIDATOR(PrepareDriveArguments, [](const Notification& notification) {
+		template<VersionType version>
+		ValidationResult handler_v1(const model::PrepareDriveNotification<version> &notification) {
 			if (notification.Duration.unwrap() <= 0)
 				return Failure_Service_Drive_Invalid_Duration;
 
@@ -39,6 +40,9 @@ namespace catapult { namespace validators {
 				return Failure_Service_Min_Replicators_More_Than_Replicas;
 
 			return ValidationResult::Success;
-		});
+		}
 	}
-}
+
+	DEFINE_STATELESS_VALIDATOR_WITH_TYPE(PrepareDriveArgumentsV1, model::PrepareDriveNotification<1>, handler_v1<1>)
+	DEFINE_STATELESS_VALIDATOR_WITH_TYPE(PrepareDriveArgumentsV2, model::PrepareDriveNotification<2>, handler_v1<2>)
+}}

--- a/plugins/txes/service/src/validators/PrepareDrivePermissionValidator.cpp
+++ b/plugins/txes/service/src/validators/PrepareDrivePermissionValidator.cpp
@@ -8,14 +8,18 @@
 #include "src/cache/DriveCache.h"
 
 namespace catapult { namespace validators {
+	namespace {
+		template<VersionType version>
+		ValidationResult handler_v1(const model::PrepareDriveNotification<version> &notification, const ValidatorContext& context) {
+			const auto& driveCache = context.Cache.sub<cache::DriveCache>();
+			if (driveCache.contains(notification.DriveKey))
+				return Failure_Service_Drive_Already_Exists;
 
-	using Notification = model::PrepareDriveNotification<1>;
+			return ValidationResult::Success;
+		}
+	}
 
-	DEFINE_STATEFUL_VALIDATOR(PrepareDrivePermission, [](const Notification& notification, const ValidatorContext& context) {
-		const auto& driveCache = context.Cache.sub<cache::DriveCache>();
-		if (driveCache.contains(notification.DriveKey))
-			return Failure_Service_Drive_Already_Exists;
+	DEFINE_STATEFUL_VALIDATOR_WITH_TYPE(PrepareDrivePermissionV1, model::PrepareDriveNotification<1>, handler_v1<1>)
+	DEFINE_STATEFUL_VALIDATOR_WITH_TYPE(PrepareDrivePermissionV2, model::PrepareDriveNotification<2>, handler_v1<2>)
 
-		return ValidationResult::Success;
-	});
 }}

--- a/plugins/txes/service/src/validators/Validators.h
+++ b/plugins/txes/service/src/validators/Validators.h
@@ -25,11 +25,13 @@ namespace catapult { namespace validators {
 	/// - duration % billingPeriod == 0
 	/// - Percent approvers in range 0-100
 	/// - Min replicators <= replicas
-	DECLARE_STATELESS_VALIDATOR(PrepareDriveArguments, model::PrepareDriveNotification<1>)();
+	DECLARE_STATELESS_VALIDATOR(PrepareDriveArgumentsV1, model::PrepareDriveNotification<1>)();
+	DECLARE_STATELESS_VALIDATOR(PrepareDriveArgumentsV2, model::PrepareDriveNotification<2>)();
 
 	/// A validator implementation that applies to drive prepare drive notifications and validates that:
 	/// - the drive is not exist
-	DECLARE_STATEFUL_VALIDATOR(PrepareDrivePermission, model::PrepareDriveNotification<1>)();
+	DECLARE_STATEFUL_VALIDATOR(PrepareDrivePermissionV1, model::PrepareDriveNotification<1>)();
+	DECLARE_STATEFUL_VALIDATOR(PrepareDrivePermissionV2, model::PrepareDriveNotification<2>)();
 
 	/// A validator check that operation is permitted by drive multisig.
 	DECLARE_STATEFUL_VALIDATOR(DrivePermittedOperation, model::AggregateEmbeddedTransactionNotification<1>)();

--- a/plugins/txes/service/tests/model/PrepareDriveTransactionTests.cpp
+++ b/plugins/txes/service/tests/model/PrepareDriveTransactionTests.cpp
@@ -41,7 +41,7 @@ namespace catapult { namespace model {
 		void AssertTransactionHasExpectedProperties() {
 			// Assert:
 			EXPECT_EQ(Entity_Type_PrepareDrive, static_cast<EntityType>(T::Entity_Type));
-			EXPECT_EQ(2u, static_cast<VersionType>(T::Current_Version));
+			EXPECT_EQ(3u, static_cast<VersionType>(T::Current_Version));
 		}
 	}
 

--- a/plugins/txes/service/tests/observers/PrepareDriveObserverTests.cpp
+++ b/plugins/txes/service/tests/observers/PrepareDriveObserverTests.cpp
@@ -14,7 +14,8 @@ namespace catapult { namespace observers {
 
 #define TEST_CLASS PrepareDriveObserverTests
 
-	DEFINE_COMMON_OBSERVER_TESTS(PrepareDrive, )
+	DEFINE_COMMON_OBSERVER_TESTS(PrepareDriveV1, )
+	DEFINE_COMMON_OBSERVER_TESTS(PrepareDriveV2, )
 
 	namespace {
 		using ObserverTestContext = test::ObserverTestContextT<test::DriveCacheFactory>;
@@ -31,7 +32,28 @@ namespace catapult { namespace observers {
 		const uint16_t Min_Replicators = test::Random16();
 		const uint8_t Percent_Approvers = test::RandomByte();
 
-		std::unique_ptr<state::DriveEntry> CreateDriveEntry() {
+		template<VersionType Version>
+		std::unique_ptr<model::PrepareDriveNotification<Version>> CreateNotification() {
+			return std::make_unique<model::PrepareDriveNotification<Version>>(model::PrepareDriveNotification<Version>(
+				Drive_Key,
+				Owner,
+				Duration,
+				Billing_Period,
+				Billing_Price,
+				Size,
+				Replicas,
+				Min_Replicators,
+				Percent_Approvers));
+		}
+	}
+
+	struct PrepareObserverV1Traits {
+		static constexpr VersionType Version = 1;
+		static auto CreateObserver() {
+			return CreatePrepareDriveV1Observer();
+		}
+
+		static std::unique_ptr<state::DriveEntry> CreateDriveEntry() {
 			auto pEntry = std::make_unique<state::DriveEntry>(state::DriveEntry(Drive_Key));
 			pEntry->setState(state::DriveState::NotStarted);
 			pEntry->setOwner(Owner);
@@ -46,28 +68,45 @@ namespace catapult { namespace observers {
 
 			return pEntry;
 		}
+	};
 
-		std::unique_ptr<Notification> CreateNotification() {
-			return std::make_unique<Notification>(Notification(
-				Drive_Key,
-				Owner,
-				Duration,
-				Billing_Period,
-				Billing_Price,
-				Size,
-				Replicas,
-				Min_Replicators,
-				Percent_Approvers));
+	struct PrepareObserverV2Traits {
+		static constexpr VersionType Version = 2;
+		static auto CreateObserver() {
+			return CreatePrepareDriveV2Observer();
 		}
-	}
 
-	TEST(TEST_CLASS, PrepareDrive_Commit) {
+		static std::unique_ptr<state::DriveEntry> CreateDriveEntry() {
+			auto pEntry = std::make_unique<state::DriveEntry>(state::DriveEntry(Drive_Key));
+			pEntry->setState(state::DriveState::NotStarted);
+			pEntry->setOwner(Owner);
+			pEntry->setStart(Current_Height);
+			pEntry->setDuration(Duration);
+			pEntry->setBillingPeriod(Billing_Period);
+			pEntry->setBillingPrice(Billing_Price);
+			pEntry->setSize(Size);
+			pEntry->setReplicas(Replicas);
+			pEntry->setMinReplicators(Min_Replicators);
+			pEntry->setPercentApprovers(Percent_Approvers);
+			pEntry->setVersion(3);
+
+			return pEntry;
+		}
+	};
+
+#define TRAITS_BASED_TEST(TEST_NAME) \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)(); \
+	TEST(TEST_CLASS, TEST_NAME##_v1) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PrepareObserverV1Traits>(); } \
+	TEST(TEST_CLASS, TEST_NAME##_v2) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PrepareObserverV2Traits>(); } \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)()
+
+	TRAITS_BASED_TEST(PrepareDrive_Commit) {
 		// Arrange:
 		ObserverTestContext context(NotifyMode::Commit, Current_Height);
-		auto pNotification = CreateNotification();
-		auto pObserver = CreatePrepareDriveObserver();
+		auto pNotification = CreateNotification<TTraits::Version>();
+		auto pObserver = TTraits::CreateObserver();
 		auto& driveCache = context.cache().sub<cache::DriveCache>();
-		auto pExpectedDriveEntry = CreateDriveEntry();
+		auto pExpectedDriveEntry = TTraits::CreateDriveEntry();
 
 		// Act:
 		test::ObserveNotification(*pObserver, *pNotification, context);
@@ -78,13 +117,13 @@ namespace catapult { namespace observers {
 		test::AssertEqualDriveData(*pExpectedDriveEntry, actualEntry);
 	}
 
-	TEST(TEST_CLASS, PrepareDrive_Rollback) {
+	TRAITS_BASED_TEST(PrepareDrive_Rollback) {
 		// Arrange:
 		ObserverTestContext context(NotifyMode::Rollback, Current_Height);
-		auto pNotification = CreateNotification();
-		auto pObserver = CreatePrepareDriveObserver();
+		auto pNotification = CreateNotification<TTraits::Version>();
+		auto pObserver = TTraits::CreateObserver();
 		auto& driveCache = context.cache().sub<cache::DriveCache>();
-		auto pEntry = CreateDriveEntry();
+		auto pEntry = TTraits::CreateDriveEntry();
 
 		// Populate drive cache.
 		driveCache.insert(*pEntry);

--- a/plugins/txes/service/tests/plugins/PrepareDriveTransactionPluginTests.cpp
+++ b/plugins/txes/service/tests/plugins/PrepareDriveTransactionPluginTests.cpp
@@ -18,7 +18,7 @@ namespace catapult { namespace plugins {
 #define TEST_CLASS PrepareDriveTransactionPluginTests
 
 	namespace {
-		DEFINE_TRANSACTION_PLUGIN_TEST_TRAITS(PrepareDrive, 2, 2,)
+		DEFINE_TRANSACTION_PLUGIN_TEST_TRAITS(PrepareDrive, 3, 3,)
 
 		template<typename TTraits>
 		auto CreateTransaction(VersionType version) {
@@ -51,6 +51,10 @@ namespace catapult { namespace plugins {
 			AssertCanCalculateSize<TTraits>(2);
 	}
 
+	PLUGIN_TEST(CanCalculateSize_v3) {
+			AssertCanCalculateSize<TTraits>(3);
+	}
+
 	// region publish - basic
 
 	PLUGIN_TEST(PublishesNoNotificationWhenTransactionVersionIsInvalid) {
@@ -71,7 +75,7 @@ namespace catapult { namespace plugins {
 
 	namespace {
 		template<typename TTraits>
-		void AssertCanPublishCorrectNumberOfNotifications(VersionType version) {
+		void AssertCanPublishCorrectNumberOfNotifications(VersionType version, NotificationType expectedNotification) {
 			// Arrange:
 			auto pTransaction = CreateTransaction<TTraits>(version);
 			mocks::MockNotificationSubscriber sub;
@@ -82,16 +86,20 @@ namespace catapult { namespace plugins {
 
 			// Assert:
 			ASSERT_EQ(1, sub.numNotifications());
-			EXPECT_EQ(Service_Prepare_Drive_v1_Notification, sub.notificationTypes()[0]);
+			EXPECT_EQ(expectedNotification, sub.notificationTypes()[0]);
 		}
 	}
 
 	PLUGIN_TEST(CanPublishCorrectNumberOfNotifications_v1) {
-		AssertCanPublishCorrectNumberOfNotifications<TTraits>(1);
+		AssertCanPublishCorrectNumberOfNotifications<TTraits>(1, Service_Prepare_Drive_v1_Notification);
 	}
 
 	PLUGIN_TEST(CanPublishCorrectNumberOfNotifications_v2) {
-		AssertCanPublishCorrectNumberOfNotifications<TTraits>(2);
+		AssertCanPublishCorrectNumberOfNotifications<TTraits>(2, Service_Prepare_Drive_v1_Notification);
+	}
+
+	PLUGIN_TEST(CanPublishCorrectNumberOfNotifications_v3) {
+		AssertCanPublishCorrectNumberOfNotifications<TTraits>(3, Service_Prepare_Drive_v2_Notification);
 	}
 
 	// endregion
@@ -99,10 +107,10 @@ namespace catapult { namespace plugins {
 	// region publish - prepare drive notification
 
 	namespace {
-		template<typename TTraits>
+		template<typename TTraits, VersionType Version>
 		void AssertCanPublishPrepareDriveNotification(VersionType version) {
 			// Arrange:
-			mocks::MockTypedNotificationSubscriber<PrepareDriveNotification<1>> sub;
+			mocks::MockTypedNotificationSubscriber<PrepareDriveNotification<Version>> sub;
 			auto pPlugin = TTraits::CreatePlugin();
 
 			auto pTransaction = CreateTransaction<TTraits>(version);
@@ -130,11 +138,15 @@ namespace catapult { namespace plugins {
 	}
 
 	PLUGIN_TEST(CanPublishPrepareDriveNotification_v1) {
-		AssertCanPublishPrepareDriveNotification<TTraits>(1);
+		AssertCanPublishPrepareDriveNotification<TTraits, 1>(1);
 	}
 
 	PLUGIN_TEST(CanPublishPrepareDriveNotification_v2) {
-		AssertCanPublishPrepareDriveNotification<TTraits>(2);
+		AssertCanPublishPrepareDriveNotification<TTraits, 1>(2);
+	}
+
+	PLUGIN_TEST(CanPublishPrepareDriveNotification_v3) {
+		AssertCanPublishPrepareDriveNotification<TTraits, 2>(3);
 	}
 
 	// endregion

--- a/plugins/txes/service/tests/plugins/ServicePluginTests.cpp
+++ b/plugins/txes/service/tests/plugins/ServicePluginTests.cpp
@@ -72,7 +72,8 @@ namespace catapult { namespace plugins {
 				return {
 					"ServicePluginConfigValidator",
 					"FailedBlockHashesValidator",
-					"PrepareDriveArgumentsValidator",
+					"PrepareDriveArgumentsV1Validator",
+					"PrepareDriveArgumentsV2Validator",
 				};
 			}
 
@@ -82,7 +83,7 @@ namespace catapult { namespace plugins {
 					"StartDriveVerificationValidator",
 					"EndDriveVerificationValidator",
 					"DriveValidator",
-					"PrepareDrivePermissionValidator",
+					"PrepareDrivePermissionV1Validator",
 					"DriveFileSystemValidator",
 					"MaxFilesOnDriveValidator",
 					"JoinToDriveValidator",
@@ -91,6 +92,7 @@ namespace catapult { namespace plugins {
 					"DriveFilesRewardValidator",
 					"StartFileDownloadValidator",
 					"EndFileDownloadValidator",
+					"PrepareDrivePermissionV2Validator",
 					"ExchangeV1Validator",
 					"ExchangeV2Validator",
 				};
@@ -104,7 +106,7 @@ namespace catapult { namespace plugins {
 					"DownloadCacheTouchObserver",
 					"DownloadCachePruningObserver",
 					"StartBillingObserver",
-					"PrepareDriveObserver",
+					"PrepareDriveV1Observer",
 					"DriveFileSystemObserver",
 					"JoinToDriveObserver",
 					"FilesDepositObserver",
@@ -112,6 +114,7 @@ namespace catapult { namespace plugins {
 					"DriveFilesRewardObserver",
 					"StartFileDownloadObserver",
 					"EndFileDownloadObserver",
+					"PrepareDriveV2Observer",
 				};
 			}
 

--- a/plugins/txes/service/tests/test/ServiceTestUtils.cpp
+++ b/plugins/txes/service/tests/test/ServiceTestUtils.cpp
@@ -196,6 +196,7 @@ namespace catapult { namespace test {
 		EXPECT_EQ(expectedEntry.duration(), entry.duration());
 		EXPECT_EQ(expectedEntry.billingPeriod(), entry.billingPeriod());
 		EXPECT_EQ(expectedEntry.billingPrice(), entry.billingPrice());
+		EXPECT_EQ(expectedEntry.version(), entry.version());
 
 		const auto& expectedBillingHistory = expectedEntry.billingHistory();
 		const auto& billingHistory = entry.billingHistory();

--- a/plugins/txes/service/tests/validators/PrepareDriveArgumentsValidatorTests.cpp
+++ b/plugins/txes/service/tests/validators/PrepareDriveArgumentsValidatorTests.cpp
@@ -12,13 +12,14 @@ namespace catapult { namespace validators {
 
 #define TEST_CLASS PrepareDriveArgumentsValidatorTests
 
-	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDriveArguments, )
+	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDriveArgumentsV1, )
+	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDriveArgumentsV2, )
 
 	namespace {
-		using Notification = model::PrepareDriveNotification<1>;
 
+		template<VersionType Version>
 		auto CreateNotification() {
-			return validators::Notification(
+			return model::PrepareDriveNotification<Version>(
 				test::GenerateRandomByteArray<Key>(),
 				test::GenerateRandomByteArray<Key>(),
 				BlockDuration(500),
@@ -31,11 +32,12 @@ namespace catapult { namespace validators {
 			);
 		}
 
+		template<typename TTraits>
 		void AssertValidationResult(
 				ValidationResult expectedResult,
-				const Notification& notification) {
+				const model::PrepareDriveNotification<TTraits::Version>& notification) {
 			// Arrange:
-			auto pValidator = CreatePrepareDriveArgumentsValidator();
+			auto pValidator = TTraits::CreateValidator();
 
 			// Act:
 			auto result = test::ValidateNotification(*pValidator, notification);
@@ -45,112 +47,132 @@ namespace catapult { namespace validators {
 		}
 	}
 
-	TEST(TEST_CLASS, FailureWhenDurationInvalid) {
+	struct PrepareValidatorV1Traits {
+		static constexpr VersionType Version = 1;
+		static auto CreateValidator() {
+			return CreatePrepareDriveArgumentsV1Validator();
+		}
+	};
+
+	struct PrepareValidatorV2Traits {
+		static constexpr VersionType Version = 2;
+		static auto CreateValidator() {
+			return CreatePrepareDriveArgumentsV2Validator();
+		}
+	};
+
+#define TRAITS_BASED_TEST(TEST_NAME) \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)(); \
+	TEST(TEST_CLASS, TEST_NAME##_v1) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PrepareValidatorV1Traits>(); } \
+	TEST(TEST_CLASS, TEST_NAME##_v2) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PrepareValidatorV2Traits>(); } \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)()
+
+	TRAITS_BASED_TEST(FailureWhenDurationInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.Duration = BlockDuration(0);
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Duration,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenBillingPeriodInvalid) {
+	TRAITS_BASED_TEST(FailureWhenBillingPeriodInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.BillingPeriod = BlockDuration(0);
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Billing_Period,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenBillingPriceInvalid) {
+	TRAITS_BASED_TEST(FailureWhenBillingPriceInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.BillingPrice = Amount(0);
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Billing_Price,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenDurationIsNotMultipleOfBillingPeriodInvalid) {
+	TRAITS_BASED_TEST(FailureWhenDurationIsNotMultipleOfBillingPeriodInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.Duration = BlockDuration(7);
 		notification.BillingPeriod = BlockDuration(3);
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Duration_Is_Not_Multiple_Of_BillingPeriod,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenDriveSizeInvalid) {
+	TRAITS_BASED_TEST(FailureWhenDriveSizeInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.DriveSize = 0;
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Size,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenReplicasInvalid) {
+	TRAITS_BASED_TEST(FailureWhenReplicasInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.Replicas = 0;
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Replicas,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenPercentApproversInvalid) {
+	TRAITS_BASED_TEST(FailureWhenPercentApproversInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.PercentApprovers = 200;
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Wrong_Percent_Approvers,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenMinReplicatorsInvalid) {
+	TRAITS_BASED_TEST(FailureWhenMinReplicatorsInvalid) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.MinReplicators = 0;
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Invalid_Min_Replicators,
 			notification);
 	}
 
-	TEST(TEST_CLASS, FailureWhenMinReplicatorsExceedsReplicas) {
+	TRAITS_BASED_TEST(FailureWhenMinReplicatorsExceedsReplicas) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 		notification.MinReplicators = notification.Replicas + 1;
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Min_Replicators_More_Than_Replicas,
 			notification);
 	}
 
-	TEST(TEST_CLASS, Success) {
+	TRAITS_BASED_TEST(Success) {
 		// Arrange:
-		auto notification = CreateNotification();
+		auto notification = CreateNotification<TTraits::Version>();
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			ValidationResult::Success,
 			notification);
 	}

--- a/plugins/txes/service/tests/validators/PrepareDrivePermissionValidatorTests.cpp
+++ b/plugins/txes/service/tests/validators/PrepareDrivePermissionValidatorTests.cpp
@@ -14,11 +14,12 @@ namespace catapult { namespace validators {
 
 #define TEST_CLASS PrepareDrivePermissionValidatorTests
 
-	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDrivePermission, )
+	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDrivePermissionV1, )
+	DEFINE_COMMON_VALIDATOR_TESTS(PrepareDrivePermissionV2, )
 
 	namespace {
-		using Notification = model::PrepareDriveNotification<1>;
 
+		template<typename TTraits>
 		void AssertValidationResult(
 				ValidationResult expectedResult,
 				const state::DriveEntry* pDriveEntry,
@@ -32,8 +33,8 @@ namespace catapult { namespace validators {
 				driveCacheDelta.insert(*pDriveEntry);
 				cache.commit(currentHeight);
 			}
-			Notification notification(driveKey, Key(), BlockDuration(), BlockDuration(), Amount(), 0, 0, 0, 0);
-			auto pValidator = CreatePrepareDrivePermissionValidator();
+			model::PrepareDriveNotification<TTraits::Version> notification(driveKey, Key(), BlockDuration(), BlockDuration(), Amount(), 0, 0, 0, 0);
+			auto pValidator = TTraits::CreateValidator();
 
 			// Act:
 			auto result = test::ValidateNotification(*pValidator, notification, cache,
@@ -44,20 +45,40 @@ namespace catapult { namespace validators {
 		}
 	}
 
-	TEST(TEST_CLASS, FailureWhenDriveExists) {
+	struct PreparePermissionValidatorV1Traits {
+		static constexpr VersionType Version = 1;
+		static auto CreateValidator() {
+			return CreatePrepareDrivePermissionV1Validator();
+		}
+	};
+
+	struct PreparePermissionValidatorV2Traits {
+		static constexpr VersionType Version = 2;
+		static auto CreateValidator() {
+			return CreatePrepareDrivePermissionV2Validator();
+		}
+	};
+
+#define TRAITS_BASED_TEST(TEST_NAME) \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)(); \
+	TEST(TEST_CLASS, TEST_NAME##_v1) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PreparePermissionValidatorV1Traits>(); } \
+	TEST(TEST_CLASS, TEST_NAME##_v2) { TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)<PreparePermissionValidatorV2Traits>(); } \
+	template<typename TTraits> void TRAITS_TEST_NAME(TEST_CLASS, TEST_NAME)()
+
+	TRAITS_BASED_TEST(FailureWhenDriveExists) {
 		// Arrange:
 		state::DriveEntry driveEntry(test::GenerateRandomByteArray<Key>());
 
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			Failure_Service_Drive_Already_Exists,
 			&driveEntry,
 			driveEntry.key());
 	}
 
-	TEST(TEST_CLASS, Success) {
+	TRAITS_BASED_TEST(Success) {
 		// Assert:
-		AssertValidationResult(
+		AssertValidationResult<TTraits>(
 			ValidationResult::Success,
 			nullptr,
 			test::GenerateRandomByteArray<Key>());

--- a/resources/supported-entities.json
+++ b/resources/supported-entities.json
@@ -123,7 +123,7 @@
 		{
 			"name": "PrepareDrive",
 			"type": "16730",
-			"supportedVersions": [2]
+			"supportedVersions": [3]
 		},
 		{
 			"name": "JoinToDrive",

--- a/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/api_node/resources/supported-entities.json
@@ -123,7 +123,7 @@
 		{
 			"name": "PrepareDrive",
 			"type": "16730",
-			"supportedVersions": [2]
+			"supportedVersions": [3]
 		},
 		{
 			"name": "JoinToDrive",

--- a/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
+++ b/scripts/bootstrap/ruby/catapult-templates/peer_node/resources/supported-entities.json
@@ -123,7 +123,7 @@
 		{
 			"name": "PrepareDrive",
 			"type": "16730",
-			"supportedVersions": [2]
+			"supportedVersions": [3]
 		},
 		{
 			"name": "JoinToDrive",


### PR DESCRIPTION
Removed cleaning of drive after the end, because we don't need clean any entry in drive because during rollback we can't restore this data.

Added version 3 of drive entry and a new version of PrepareDriveTransaction.