### PR TITLE
Can't remove cosigner from multilevel multisig

### DIFF
--- a/plugins/txes/multisig/src/validators/ModifyMultisigInvalidSettingsValidator.cpp
+++ b/plugins/txes/multisig/src/validators/ModifyMultisigInvalidSettingsValidator.cpp
@@ -31,10 +31,10 @@ namespace catapult { namespace validators {
 		if (!multisigCache.contains(notification.Signer)) {
 			// since the ModifyMultisigInvalidCosignersValidator and the ModifyMultisigCosignersObserver ran before
 			// this validator, the only scenario in which the multisig account cannot be found in the multisig cache
-			// is that the observer removed the last cosigner reverting the multisig account to a normal accounts
+			// is that the observer removed the last cosigners reverting the multisig account to a normal accounts
 
-			// MinRemovalDelta and MinApprovalDelta are both expected to be -1 in this case
-			if (-1 != notification.MinRemovalDelta || -1 != notification.MinApprovalDelta)
+			// MinRemovalDelta and MinApprovalDelta are both expected to be -X in this case
+			if (notification.MinRemovalDelta != notification.MinApprovalDelta)
 				return Failure_Multisig_Modify_Min_Setting_Out_Of_Range;
 
 			return ValidationResult::Success;
@@ -42,9 +42,10 @@ namespace catapult { namespace validators {
 
 		auto multisigIter = multisigCache.find(notification.Signer);
 		const auto& multisigEntry = multisigIter.get();
-		int newMinRemoval = multisigEntry.minRemoval() + notification.MinRemovalDelta;
-		int newMinApproval = multisigEntry.minApproval() + notification.MinApprovalDelta;
-		if (1 > newMinRemoval || 1 > newMinApproval)
+		int newMinRemoval = static_cast<int32_t>(multisigEntry.minRemoval()) + notification.MinRemovalDelta;
+		int newMinApproval = static_cast<int32_t>(multisigEntry.minApproval()) + notification.MinApprovalDelta;
+		if (0 > newMinRemoval || 0 > newMinApproval
+			|| !multisigEntry.cosignatories().empty() && (newMinRemoval == 0 || newMinApproval == 0))
 			return Failure_Multisig_Modify_Min_Setting_Out_Of_Range;
 
 		int maxValue = static_cast<int>(multisigEntry.cosignatories().size());

--- a/scripts/mongo/mongoServiceDbPrepare.js
+++ b/scripts/mongo/mongoServiceDbPrepare.js
@@ -3,6 +3,7 @@
 	db.drives.createIndex({ 'drive.multisig': 1 }, { unique: true });
 	db.drives.createIndex({ 'drive.multisigAddress': 1 }, { unique: true });
 	db.drives.createIndex({ 'drive.owner': 1 }, { unique: false });
+	db.drives.createIndex({ 'drive.state': 1 }, { unique: false });
 	db.drives.createIndex({ 'drive.replicators.replicator': 1 }, { unique: false });
 
 	db.createCollection('downloads');


### PR DESCRIPTION
We can have case that account in multisig cache(when account is part of some multisig too), but count of cosigner is zero, so in this case we can change setting.