### PR TITLE
During stateless validation use config at height X

### DIFF
--- a/src/catapult/config_holder/BlockchainConfigurationHolder.cpp
+++ b/src/catapult/config_holder/BlockchainConfigurationHolder.cpp
@@ -40,8 +40,8 @@ namespace catapult { namespace config {
 		return boost::filesystem::path(argc > 1 ? argv[1] : "..") / "resources";
 	}
 
-	const BlockchainConfiguration& BlockchainConfigurationHolder::Config(const Height& height) {
-		std::lock_guard<std::mutex> guard(m_mutex);
+	const BlockchainConfiguration& BlockchainConfigurationHolder::Config(const Height& height) const {
+		std::shared_lock lock(m_mutex);
 
 		auto iter = m_configs.lower_bound(height);
 
@@ -59,18 +59,18 @@ namespace catapult { namespace config {
 		return iter->second;
 	}
 
-	const BlockchainConfiguration& BlockchainConfigurationHolder::Config() {
+	const BlockchainConfiguration& BlockchainConfigurationHolder::Config() const {
 		return Config(m_pCache != nullptr ? m_pCache->configHeight() : Height(0));
 	}
 
-	const BlockchainConfiguration& BlockchainConfigurationHolder::ConfigAtHeightOrLatest(const Height& height) {
+	const BlockchainConfiguration& BlockchainConfigurationHolder::ConfigAtHeightOrLatest(const Height& height) const {
 		if (height == HEIGHT_OF_LATEST_CONFIG)
 			return Config();
 		return Config(height);
 	}
 
 	void BlockchainConfigurationHolder::InsertConfig(const Height& height, const std::string& strConfig, const std::string& supportedVersion) {
-		std::lock_guard<std::mutex> guard(m_mutex);
+		std::unique_lock lock(m_mutex);
 
 		try {
 			std::istringstream inputBlock(strConfig);
@@ -101,7 +101,7 @@ namespace catapult { namespace config {
 	}
 
 	void BlockchainConfigurationHolder::RemoveConfig(const Height& height){
-		std::lock_guard<std::mutex> guard(m_mutex);
+		std::unique_lock lock(m_mutex);
 		m_configs.erase(height);
 	}
 }}

--- a/src/catapult/config_holder/BlockchainConfigurationHolder.h
+++ b/src/catapult/config_holder/BlockchainConfigurationHolder.h
@@ -6,7 +6,8 @@
 
 #pragma once
 #include "catapult/config/BlockchainConfiguration.h"
-#include <mutex>
+#include <mutex>  // For std::unique_lock
+#include <shared_mutex>
 
 namespace catapult { namespace cache { class CatapultCache; } }
 
@@ -29,13 +30,13 @@ namespace catapult { namespace config {
 		static boost::filesystem::path GetResourcesPath(int argc, const char** argv);
 
 		/// Get \a config at \a height
-		virtual const BlockchainConfiguration& Config(const Height& height);
+		virtual const BlockchainConfiguration& Config(const Height& height) const;
 
 		/// Get latest available config
-		virtual const BlockchainConfiguration& Config();
+		virtual const BlockchainConfiguration& Config() const;
 
 		/// Get config at \a height or latest available config
-		virtual const BlockchainConfiguration& ConfigAtHeightOrLatest(const Height& height);
+		virtual const BlockchainConfiguration& ConfigAtHeightOrLatest(const Height& height) const;
 
 		void SetCache(cache::CatapultCache* pCache) {
 			m_pCache = pCache;
@@ -52,6 +53,6 @@ namespace catapult { namespace config {
 		std::map<Height, BlockchainConfiguration> m_configs;
 		cache::CatapultCache* m_pCache;
 		PluginInitializer m_pluginInitializer;
-		std::mutex m_mutex;
+		mutable std::shared_mutex m_mutex;
 	};
 }}

--- a/src/catapult/consumers/StatelessValidationConsumer.cpp
+++ b/src/catapult/consumers/StatelessValidationConsumer.cpp
@@ -36,8 +36,7 @@ namespace catapult { namespace consumers {
 				const std::shared_ptr<config::BlockchainConfigurationHolder>& pConfigHolder,
 				TExtractAndProcess extractAndProcess) {
 			return [pValidator, extractAndProcess, pConfigHolder](auto& elements) {
-			  validators::StatelessValidatorContext context(pConfigHolder->Config());
-			  validators::stateless::AggregateEntityValidator::DispatchForwarder dispatcher(pValidator->curry(std::cref(context)));
+			  	validators::stateless::AggregateEntityValidator::DispatchForwarder dispatcher(pValidator->curryStateless(pConfigHolder));
 				if (elements.empty())
 					return Abort(Failure_Consumer_Empty_Input);
 

--- a/src/catapult/validators/AggregateEntityValidator.h
+++ b/src/catapult/validators/AggregateEntityValidator.h
@@ -22,6 +22,7 @@
 #include "ValidatorTypes.h"
 #include "catapult/model/VerifiableEntity.h"
 #include "catapult/utils/NamedObject.h"
+#include "StatelessValidatorContext.h"
 #include <memory>
 
 namespace catapult { namespace validators {
@@ -73,6 +74,19 @@ namespace catapult { namespace validators {
 			for (const auto& pValidator : m_validators) {
 				validationFunctions.emplace_back([&pValidator, forwardedArgs](const auto& entityInfo) {
 					return pValidator->validate(entityInfo, std::get<TArgs>(forwardedArgs)...);
+				});
+			}
+
+			return DispatchForwarder(std::move(validationFunctions));
+		}
+
+		DispatchForwarder curryStateless(const std::shared_ptr<config::BlockchainConfigurationHolder>& pConfigHolder) const {
+			ValidationFunctions validationFunctions;
+			validationFunctions.reserve(m_validators.size());
+			for (const auto& pValidator : m_validators) {
+				validationFunctions.emplace_back([&pValidator, &pConfigHolder](const model::WeakEntityInfo& entityInfo) {
+				  	validators::StatelessValidatorContext context(pConfigHolder->Config(entityInfo.associatedHeight()));
+					return pValidator->validate(entityInfo, context);
 				});
 			}
 

--- a/tests/catapult/config_holder/BlockchainConfigurationHolderTests.cpp
+++ b/tests/catapult/config_holder/BlockchainConfigurationHolderTests.cpp
@@ -175,13 +175,13 @@ namespace catapult { namespace config {
 				, NetworkConfig(test::MutableBlockchainConfiguration().ToConst())
 			{}
 
-			BlockchainConfiguration& Config(const Height& height) override {
+			const BlockchainConfiguration& Config(const Height& height) const override {
 				ConfigCalledAtHeight = height;
 				return NetworkConfig;
 			}
 
 		public:
-			Height ConfigCalledAtHeight;
+			mutable Height ConfigCalledAtHeight;
 			BlockchainConfiguration NetworkConfig;
 		};
 	}
@@ -226,19 +226,19 @@ namespace catapult { namespace config {
 				, NetworkConfig(test::MutableBlockchainConfiguration().ToConst())
 			{}
 
-			BlockchainConfiguration& Config(const Height&) override {
+			const BlockchainConfiguration& Config(const Height&) const override {
 				ConfigAtHeightCalled = true;
 				return NetworkConfig;
 			}
 
-			BlockchainConfiguration& Config() override {
+			const BlockchainConfiguration& Config() const override {
 				ConfigCalled = true;
 				return NetworkConfig;
 			}
 
 		public:
-			bool ConfigAtHeightCalled = false;
-			bool ConfigCalled = false;
+			mutable bool ConfigAtHeightCalled = false;
+			mutable bool ConfigCalled = false;
 			BlockchainConfiguration NetworkConfig;
 		};
 	}

--- a/tests/test/core/mocks/MockBlockchainConfigurationHolder.cpp
+++ b/tests/test/core/mocks/MockBlockchainConfigurationHolder.cpp
@@ -28,15 +28,15 @@ namespace catapult { namespace config {
 			: BlockchainConfigurationHolder(config) {
 	}
 
-	const BlockchainConfiguration& MockBlockchainConfigurationHolder::Config(const Height&) {
+	const BlockchainConfiguration& MockBlockchainConfigurationHolder::Config(const Height&) const {
 		return m_configs.at(Height{0});
 	}
 
-	const BlockchainConfiguration& MockBlockchainConfigurationHolder::Config() {
+	const BlockchainConfiguration& MockBlockchainConfigurationHolder::Config() const {
 		return m_configs.at(Height{0});
 	}
 
-	const BlockchainConfiguration& MockBlockchainConfigurationHolder::ConfigAtHeightOrLatest(const Height&) {
+	const BlockchainConfiguration& MockBlockchainConfigurationHolder::ConfigAtHeightOrLatest(const Height&) const {
 		return m_configs.at(Height{0});
 	}
 

--- a/tests/test/core/mocks/MockBlockchainConfigurationHolder.h
+++ b/tests/test/core/mocks/MockBlockchainConfigurationHolder.h
@@ -18,9 +18,9 @@ namespace catapult { namespace config {
 		MockBlockchainConfigurationHolder(const BlockchainConfiguration& config);
 
 	public:
-		const BlockchainConfiguration& Config(const Height&) override;
-		const BlockchainConfiguration& Config() override;
-		const BlockchainConfiguration& ConfigAtHeightOrLatest(const Height&) override;
+		const BlockchainConfiguration& Config(const Height&) const override;
+		const BlockchainConfiguration& Config() const override;
+		const BlockchainConfiguration& ConfigAtHeightOrLatest(const Height&) const override;
 	};
 
 	std::shared_ptr<BlockchainConfigurationHolder> CreateMockConfigurationHolder();


### PR DESCRIPTION
During stateless validation use config at height X (height of block to validate), instead of latest config.

Changed mutex to shared mutex in config holder to improve performance during parallel read operations(in most cases we have only read operation from config).