### PR TITLE
Do not add multisig entry on rollback when modification count is zero

### DIFF
--- a/plugins/txes/multisig/src/model/MultisigNotifications.h
+++ b/plugins/txes/multisig/src/model/MultisigNotifications.h
@@ -118,11 +118,13 @@ namespace catapult { namespace model {
 
 	public:
 		/// Creates a notification around \a signer, \a minRemovalDelta and \a minApprovalDelta.
-		explicit ModifyMultisigSettingsNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta)
+		explicit ModifyMultisigSettingsNotification(
+				const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta, uint8_t modificationsCount)
 				: Notification(Notification_Type, sizeof(ModifyMultisigSettingsNotification<1>))
 				, Signer(signer)
 				, MinRemovalDelta(minRemovalDelta)
 				, MinApprovalDelta(minApprovalDelta)
+				, ModificationsCount(modificationsCount)
 		{}
 
 	public:
@@ -134,5 +136,8 @@ namespace catapult { namespace model {
 
 		/// Relative change of cosigs needed to approve a transaction.
 		int8_t MinApprovalDelta;
+
+		/// Count of modification in a transaction.
+		uint8_t ModificationsCount;
 	};
 }}

--- a/plugins/txes/multisig/src/observers/ModifyMultisigSettingsObserver.cpp
+++ b/plugins/txes/multisig/src/observers/ModifyMultisigSettingsObserver.cpp
@@ -37,6 +37,9 @@ namespace catapult { namespace observers {
 		if (isNotContained && observers::NotifyMode::Commit == context.Mode)
 			return;
 
+		if (isNotContained && observers::NotifyMode::Rollback == context.Mode && notification.ModificationsCount == 0)
+			return;
+
 		// note that in case of a rollback the multisig entry needs to be restored to the original state, else the multisig settings
 		// validator will reject the (invalid) min approval / removal
 		if (isNotContained)

--- a/plugins/txes/multisig/src/plugins/ModifyMultisigAccountTransactionPlugin.cpp
+++ b/plugins/txes/multisig/src/plugins/ModifyMultisigAccountTransactionPlugin.cpp
@@ -55,7 +55,11 @@ namespace catapult { namespace plugins {
 					sub.notify(AddressInteractionNotification<1>(transaction.Signer, transaction.Type, {}, addedCosignatoryKeys));
 
 				// 2. setting changes
-				sub.notify(ModifyMultisigSettingsNotification<1>(transaction.Signer, transaction.MinRemovalDelta, transaction.MinApprovalDelta));
+				sub.notify(ModifyMultisigSettingsNotification<1>(
+						transaction.Signer,
+						transaction.MinRemovalDelta,
+						transaction.MinApprovalDelta,
+						transaction.ModificationsCount));
 				break;
 			}
 

--- a/plugins/txes/multisig/tests/observers/ModifyMultisigSettingsObserverTests.cpp
+++ b/plugins/txes/multisig/tests/observers/ModifyMultisigSettingsObserverTests.cpp
@@ -34,8 +34,8 @@ namespace catapult { namespace observers {
 		using ObserverTestContext = test::ObserverTestContextT<test::MultisigCacheFactory>;
 		using Notification = model::ModifyMultisigSettingsNotification<1>;
 
-		auto CreateNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta) {
-			return Notification(signer, minRemovalDelta, minApprovalDelta);
+		auto CreateNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta, uint8_t modificationCount) {
+			return Notification(signer, minRemovalDelta, minApprovalDelta, modificationCount);
 		}
 
 		struct MultisigSettings {
@@ -87,7 +87,7 @@ namespace catapult { namespace observers {
 			static void AssertTestWithSettings(const TestSettings& removal, const TestSettings& approval) {
 				// Arrange:
 				auto signer = test::GenerateRandomByteArray<Key>();
-				auto notification = CreateNotification(signer, removal.Delta, approval.Delta);
+				auto notification = CreateNotification(signer, removal.Delta, approval.Delta, 0);
 
 				// Act + Assert:
 				RunTest(
@@ -106,7 +106,7 @@ namespace catapult { namespace observers {
 			static void AssertTestWithSettings(const TestSettings& removal, const TestSettings& approval) {
 				// Arrange:
 				auto signer = test::GenerateRandomByteArray<Key>();
-				auto notification = CreateNotification(signer, removal.Delta, approval.Delta);
+				auto notification = CreateNotification(signer, removal.Delta, approval.Delta, 0);
 
 				// Act + Assert:
 				RunTest(
@@ -154,7 +154,7 @@ namespace catapult { namespace observers {
 	TEST(TEST_CLASS, ObserverIgnoresNotificationWhenAccountIsUnknown_ModeCommit) {
 		// Arrange:
 		auto signer = test::GenerateRandomByteArray<Key>();
-		auto notification = CreateNotification(signer, -1, -2);
+		auto notification = CreateNotification(signer, -1, -2, 0);
 
 		auto pObserver = CreateModifyMultisigSettingsObserver();
 		ObserverTestContext context(NotifyMode::Commit, Height(777));
@@ -170,7 +170,7 @@ namespace catapult { namespace observers {
 	TEST(TEST_CLASS, ObserverAddsUnknownAccountToCacheAndProcessesDeltas_ModeRollback) {
 		// Arrange:
 		auto signer = test::GenerateRandomByteArray<Key>();
-		auto notification = CreateNotification(signer, -1, -2);
+		auto notification = CreateNotification(signer, -1, -2, 1);
 
 		auto pObserver = CreateModifyMultisigSettingsObserver();
 		ObserverTestContext context(NotifyMode::Rollback, Height(777));
@@ -191,6 +191,22 @@ namespace catapult { namespace observers {
 		EXPECT_EQ(1u, multisigEntry.minRemoval());
 		EXPECT_TRUE(multisigEntry.cosignatories().empty());
 		EXPECT_TRUE(multisigEntry.multisigAccounts().empty());
+	}
+
+	TEST(TEST_CLASS, ObserverAddsUnknownAccountToCacheAndProcessesDeltas_ModeRollback_ZeroModifications) {
+		// Arrange:
+		auto signer = test::GenerateRandomByteArray<Key>();
+		auto notification = CreateNotification(signer, -1, -2, 0);
+
+		auto pObserver = CreateModifyMultisigSettingsObserver();
+		ObserverTestContext context(NotifyMode::Rollback, Height(777));
+
+		// Act:
+		test::ObserveNotification(*pObserver, notification, context);
+
+		// Assert:
+		const auto& multisigCache = context.cache().sub<cache::MultisigCache>();
+		EXPECT_EQ(0u, multisigCache.size());
 	}
 
 	// endregion

--- a/plugins/txes/multisig/tests/validators/ModifyMultisigInvalidSettingsValidatorTests.cpp
+++ b/plugins/txes/multisig/tests/validators/ModifyMultisigInvalidSettingsValidatorTests.cpp
@@ -35,8 +35,8 @@ namespace catapult { namespace validators {
 	namespace {
 		using Modifications = std::vector<model::CosignatoryModification>;
 
-		auto CreateNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta) {
-			return model::ModifyMultisigSettingsNotification<1>(signer, minRemovalDelta, minApprovalDelta);
+		auto CreateNotification(const Key& signer, int8_t minRemovalDelta, int8_t minApprovalDelta, uint8_t modificationsCount) {
+			return model::ModifyMultisigSettingsNotification<1>(signer, minRemovalDelta, minApprovalDelta, modificationsCount);
 		}
 
 		auto GetValidationResult(const cache::CatapultCache& cache, const model::ModifyMultisigSettingsNotification<1>& notification) {
@@ -51,7 +51,7 @@ namespace catapult { namespace validators {
 	TEST(TEST_CLASS, SuccessWhenAccountIsUnknownAndDeltasAreSetToMinusOne) {
 		// Arrange:
 		auto signer = test::GenerateRandomByteArray<Key>();
-		auto notification = CreateNotification(signer, -1, -1);
+		auto notification = CreateNotification(signer, -1, -1, 0);
 
 		auto cache = test::MultisigCacheFactory::Create();
 
@@ -66,9 +66,9 @@ namespace catapult { namespace validators {
 		// Arrange:
 		auto signer = test::GenerateRandomByteArray<Key>();
 		std::vector<model::ModifyMultisigSettingsNotification<1>> notifications{
-			CreateNotification(signer, 0, 1),
-			CreateNotification(signer, 0, -1),
-			CreateNotification(signer, -1, 0)
+			CreateNotification(signer, 0, 1, 0),
+			CreateNotification(signer, 0, -1, 0),
+			CreateNotification(signer, -1, 0, 0)
 		};
 		std::vector<ValidationResult> results;
 
@@ -108,7 +108,7 @@ namespace catapult { namespace validators {
 			// Arrange:
 			auto keys = test::GenerateKeys(1 + numCosignatories);
 			const auto& signer = keys[0];
-			auto notification = CreateNotification(signer, removal.Delta, approval.Delta);
+			auto notification = CreateNotification(signer, removal.Delta, approval.Delta, 0);
 
 			auto cache = test::MultisigCacheFactory::Create();
 			{

--- a/plugins/txes/supercontract/src/plugins/DeployTransactionPlugin.cpp
+++ b/plugins/txes/supercontract/src/plugins/DeployTransactionPlugin.cpp
@@ -29,7 +29,7 @@ namespace catapult { namespace plugins {
 				auto pModification = sub.mempool().malloc(
 					CosignatoryModification{model::CosignatoryModificationType::Add, transaction.DriveKey});
 				sub.notify(ModifyMultisigCosignersNotification<1>(transaction.Signer, 1, pModification));
-				sub.notify(ModifyMultisigSettingsNotification<1>(transaction.Signer, 1, 1));
+				sub.notify(ModifyMultisigSettingsNotification<1>(transaction.Signer, 1, 1, 1));
 
 				sub.notify(DeployNotification<1>(
 					transaction.Signer,


### PR DESCRIPTION
During rollback of ModifyMultisigTransaction we could create multisig entry, but we didn't create it during commit mode, because the modifications count was zero. So we need to add an according to check that modification was not zero in the rollback case.